### PR TITLE
建议屏蔽双栈域名ipv6记录

### DIFF
--- a/lienol/luci-app-passwall/root/usr/share/passwall/app.sh
+++ b/lienol/luci-app-passwall/root/usr/share/passwall/app.sh
@@ -940,6 +940,9 @@ gen_pdnsd_config() {
 				interval = 60;
 				uptest = none;
 				purge_cache = off;
+				reject=::/0;
+				reject_policy=negate;
+				reject_recursively=on;
 			}
 			
 		EOF


### PR DESCRIPTION
举个栗子，downloads.openwrt.org添加到passwall黑名单，强制走代理，
但是downloads.openwrt.org有ip v4记录和ip v6记录，opkg管理器调用wget默认会采用ip v6，
而passwall插件就算勾选了“代理IPv6”，wget通过ipv6下载downloads.openwrt.org的内容时依然是没有走代理通道的，速度极慢

索性修改一下pdnsd，屏蔽掉ipv6的aaaa记录，强制双栈的gfwlist域名走ipv4代理通道