### PR TITLE
fix uhttpd cbi() error log

### DIFF
--- a/lienol/luci-app-passwall/luasrc/controller/passwall.lua
+++ b/lienol/luci-app-passwall/luasrc/controller/passwall.lua
@@ -39,7 +39,7 @@ function index()
     entry({"admin", "vpn", "passwall", "rule_list"},
           cbi("passwall/rule_list", {autoapply = true}),
           _("Set Blacklist And Whitelist"), 98).leaf = true
-    entry({"admin", "vpn", "passwall", "log"}, cbi("passwall/log"),
+    entry({"admin", "vpn", "passwall", "log"}, form("passwall/log"),
           _("Watch Logs"), 99).leaf = true
     entry({"admin", "vpn", "passwall", "node_config"},
           cbi("passwall/node_config")).leaf = true


### PR DESCRIPTION
daemon.err uhttpd[2861]: Model passwall/log returns SimpleForm but is dispatched via cbi()