### PR TITLE
v2ray-plugin Update Makefile

### DIFF
--- a/package/v2ray-plugin/Makefile
+++ b/package/v2ray-plugin/Makefile
@@ -1,76 +1,74 @@
 #
-# Copyright (C) 2018-2020 chenhw2 <https://github.com/chenhw2>
+# Copyright (C) 2020 SharerMax
 #
-# This is free software, licensed under the GNU General Public License v3.
+# This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
 #
 
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=v2ray-plugin
-PKG_VERSION:=1.3.1
-PKG_RELEASE:=20200601
-PKG_MAINTAINER:=chenhw2 <https://github.com/chenhw2>
-
-# OpenWrt ARCH: arm, i386, x86_64, mips, mipsel
-# Golang ARCH: arm[5-7], 386, amd64, mips, mipsle
-PKG_ARCH:=$(ARCH)
-BIN_ARCH:=$(ARCH)
-ifeq ($(ARCH),mips)
-    BIN_ARCH:=mips_sf
-endif
-ifeq ($(ARCH),mipsel)
-	PKG_ARCH:=mips
-	BIN_ARCH:=mipsle_sf
-endif
-ifeq ($(ARCH),i386)
-	PKG_ARCH:=386
-	BIN_ARCH:=386
-endif
-ifeq ($(ARCH),x86_64)
-	PKG_ARCH:=amd64
-	BIN_ARCH:=amd64
-endif
-ifeq ($(ARCH),aarch64)
-	PKG_ARCH:=arm64
-	BIN_ARCH:=arm64
-endif
-ifeq ($(ARCH),arm)
-	BIN_ARCH:=arm7
-endif
-ifeq ($(BOARD),bcm53xx)
-	BIN_ARCH:=arm6
-endif
-
-PKG_SOURCE:=v2ray-plugin-linux-$(PKG_ARCH)-v$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://github.com/shadowsocks/v2ray-plugin/releases/download/v$(PKG_VERSION)/
+PKG_VERSION:=1.3.3
+PKG_RELEASE:=1
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)
-PKG_HASH:=skip
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/teddysun/v2ray-plugin/tar.gz/v$(PKG_VERSION)?
+PKG_HASH:=913c6e1b6f8c57bca07685eb854ff0e00de4fd09f42b88c3b399880934410cc1
+
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
+PKG_MAINTAINER:=madeye <max.c.lv@gmail.com>
+
+PKG_BUILD_DEPENDS:=golang/host
+PKG_BUILD_PARALLEL:=1
+PKG_USE_MIPS16:=0
+
+GO_PKG:=github.com/shadowsocks/v2ray-plugin
+GO_PKG_LDFLAGS:=-s -w
+PKG_CONFIG_DEPENDS := CONFIG_$(PKG_NAME)_INCLUDE_GOPROXY
 
 include $(INCLUDE_DIR)/package.mk
+include $(TOPDIR)/feeds/packages/lang/golang/golang-package.mk
 
-define Package/v2ray-plugin
-	SECTION:=net
-	CATEGORY:=Network
-	TITLE:=SIP003 plugin for shadowsocks, based on v2ray
-	URL:=https://github.com/shadowsocks/v2ray-plugin
+define Package/$(PKG_NAME)/config
+config $(PKG_NAME)_INCLUDE_GOPROXY
+	bool "Compiling with GOPROXY proxy"
+	default y
+
 endef
 
-define Package/v2ray-plugin/description
+ifeq ($(CONFIG_$(PKG_NAME)_INCLUDE_GOPROXY),y)
+export GO111MODULE=on
+export GOPROXY=https://goproxy.io
+#export GOPROXY=https://mirrors.aliyun.com/goproxy/
+endif
+
+define Package/$(PKG_NAME)
+	SECTION:=net
+	CATEGORY:=Network
+	SUBMENU:=Project V
+	TITLE:=SIP003 plugin for shadowsocks, based on v2ray
+	URL:=https://github.com/shadowsocks/v2ray-plugin
+	DEPENDS:=$(GO_ARCH_DEPENDS) +ca-certificates
+endef
+
+define Package/$(PKG_NAME)/description
 	Yet another SIP003 plugin for shadowsocks, based on v2ray
 endef
 
 define Build/Prepare
-	gzip -dc "$(DL_DIR)/$(PKG_SOURCE)" | tar -C $(PKG_BUILD_DIR)/ -xf -
+	$(call Build/Prepare/Default)
 endef
 
 define Build/Compile
-	echo "$(PKG_NAME)Compile Skiped!"
+	$(call GoPackage/Build/Compile)
+	$(STAGING_DIR_HOST)/bin/upx --lzma --best $(GO_PKG_BUILD_BIN_DIR)/v2ray-plugin
 endef
 
-define Package/v2ray-plugin/install
+define Package/$(PKG_NAME)/install
 	$(INSTALL_DIR) $(1)/usr/bin
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/v2ray-plugin_linux_$(BIN_ARCH) $(1)/usr/bin/v2ray-plugin
+	$(INSTALL_BIN) $(GO_PKG_BUILD_BIN_DIR)/v2ray-plugin $(1)/usr/bin/v2ray-plugin
 endef
-
-$(eval $(call BuildPackage,v2ray-plugin))
+$(eval $(call GoBinPackage,$(PKG_NAME)))
+$(eval $(call BuildPackage,$(PKG_NAME)))


### PR DESCRIPTION
替换为lean大Makefile，解决v2ray-plugin在编译类似斐讯K3(ARMv7)问题：不能用arm7架构编译，只能arm5架构编译。否则用arm7或arm6架构编译，不能启动。