### PR TITLE
passwall: move to services

### DIFF
--- a/lienol/luci-app-passwall/luasrc/controller/passwall.lua
+++ b/lienol/luci-app-passwall/luasrc/controller/passwall.lua
@@ -10,59 +10,59 @@ local trojan_go = require "luci.model.cbi.passwall.api.trojan_go"
 
 function index()
 	if not nixio.fs.access("/etc/config/passwall") then return end
-	entry({"admin", "vpn"}, firstchild(), "VPN", 45).dependent = false
-	entry({"admin", "vpn", "passwall", "reset_config"}, call("reset_config")).leaf = true
-	entry({"admin", "vpn", "passwall", "show"}, call("show_menu")).leaf = true
-	entry({"admin", "vpn", "passwall", "hide"}, call("hide_menu")).leaf = true
+	entry({"admin", "services"}, firstchild(), "services", 45).dependent = false
+	entry({"admin", "services", "passwall", "reset_config"}, call("reset_config")).leaf = true
+	entry({"admin", "services", "passwall", "show"}, call("show_menu")).leaf = true
+	entry({"admin", "services", "passwall", "hide"}, call("hide_menu")).leaf = true
 	if nixio.fs.access("/etc/config/passwall") and
 		nixio.fs.access("/etc/config/passwall_show") then
-		entry({"admin", "vpn", "passwall"}, alias("admin", "vpn", "passwall", "settings"), _("Pass Wall"), 1).dependent = true
+		entry({"admin", "services", "passwall"}, alias("admin", "services", "passwall", "settings"), _("Pass Wall"), 1).dependent = true
 	end
-	entry({"admin", "vpn", "passwall", "settings"}, cbi("passwall/global"), _("Basic Settings"), 1).dependent = true
-	entry({"admin", "vpn", "passwall", "node_list"}, cbi("passwall/node_list"), _("Node List"), 2).dependent = true
-	entry({"admin", "vpn", "passwall", "auto_switch"}, cbi("passwall/auto_switch"), _("Auto Switch"), 3).leaf = true
-	entry({"admin", "vpn", "passwall", "other"}, cbi("passwall/other", {autoapply = true}), _("Other Settings"), 93).leaf = true
+	entry({"admin", "services", "passwall", "settings"}, cbi("passwall/global"), _("Basic Settings"), 1).dependent = true
+	entry({"admin", "services", "passwall", "node_list"}, cbi("passwall/node_list"), _("Node List"), 2).dependent = true
+	entry({"admin", "services", "passwall", "auto_switch"}, cbi("passwall/auto_switch"), _("Auto Switch"), 3).leaf = true
+	entry({"admin", "services", "passwall", "other"}, cbi("passwall/other", {autoapply = true}), _("Other Settings"), 93).leaf = true
 	if nixio.fs.access("/usr/sbin/haproxy") then
-		entry({"admin", "vpn", "passwall", "haproxy"}, cbi("passwall/haproxy"), _("Load Balancing"), 94).leaf = true
+		entry({"admin", "services", "passwall", "haproxy"}, cbi("passwall/haproxy"), _("Load Balancing"), 94).leaf = true
 	end
-	entry({"admin", "vpn", "passwall", "node_subscribe"}, cbi("passwall/node_subscribe"), _("Node Subscribe"), 95).dependent = true
-	entry({"admin", "vpn", "passwall", "rule"}, cbi("passwall/rule"), _("Rule Update"), 96).leaf = true
-	entry({"admin", "vpn", "passwall", "node_config"}, cbi("passwall/node_config")).leaf = true
-	entry({"admin", "vpn", "passwall", "shunt_rules"}, cbi("passwall/shunt_rules")).leaf = true
-	entry({"admin", "vpn", "passwall", "acl"}, cbi("passwall/acl"), _("Access control"), 97).leaf = true
-	entry({"admin", "vpn", "passwall", "log"}, form("passwall/log"), _("Watch Logs"), 999).leaf = true
-	entry({"admin", "vpn", "passwall", "server"}, cbi("passwall/server/index"), _("Server-Side"), 99).leaf = true
-	entry({"admin", "vpn", "passwall", "server_user"}, cbi("passwall/server/user")).leaf = true
+	entry({"admin", "services", "passwall", "node_subscribe"}, cbi("passwall/node_subscribe"), _("Node Subscribe"), 95).dependent = true
+	entry({"admin", "services", "passwall", "rule"}, cbi("passwall/rule"), _("Rule Update"), 96).leaf = true
+	entry({"admin", "services", "passwall", "node_config"}, cbi("passwall/node_config")).leaf = true
+	entry({"admin", "services", "passwall", "shunt_rules"}, cbi("passwall/shunt_rules")).leaf = true
+	entry({"admin", "services", "passwall", "acl"}, cbi("passwall/acl"), _("Access control"), 97).leaf = true
+	entry({"admin", "services", "passwall", "log"}, form("passwall/log"), _("Watch Logs"), 999).leaf = true
+	entry({"admin", "services", "passwall", "server"}, cbi("passwall/server/index"), _("Server-Side"), 99).leaf = true
+	entry({"admin", "services", "passwall", "server_user"}, cbi("passwall/server/user")).leaf = true
 
-	entry({"admin", "vpn", "passwall", "server_user_status"}, call("server_user_status")).leaf = true
-	entry({"admin", "vpn", "passwall", "server_get_log"}, call("server_get_log")).leaf = true
-	entry({"admin", "vpn", "passwall", "server_clear_log"}, call("server_clear_log")).leaf = true
-	entry({"admin", "vpn", "passwall", "link_append_temp"}, call("link_append_temp")).leaf = true
-	entry({"admin", "vpn", "passwall", "link_load_temp"}, call("link_load_temp")).leaf = true
-	entry({"admin", "vpn", "passwall", "link_clear_temp"}, call("link_clear_temp")).leaf = true
-	entry({"admin", "vpn", "passwall", "link_add_node"}, call("link_add_node")).leaf = true
-	entry({"admin", "vpn", "passwall", "get_log"}, call("get_log")).leaf = true
-	entry({"admin", "vpn", "passwall", "clear_log"}, call("clear_log")).leaf = true
-	entry({"admin", "vpn", "passwall", "status"}, call("status")).leaf = true
-	entry({"admin", "vpn", "passwall", "socks_status"}, call("socks_status")).leaf = true
-	entry({"admin", "vpn", "passwall", "connect_status"}, call("connect_status")).leaf = true
-	entry({"admin", "vpn", "passwall", "check_port"}, call("check_port")).leaf = true
-	entry({"admin", "vpn", "passwall", "ping_node"}, call("ping_node")).leaf = true
-	entry({"admin", "vpn", "passwall", "set_node"}, call("set_node")).leaf = true
-	entry({"admin", "vpn", "passwall", "copy_node"}, call("copy_node")).leaf = true
-	entry({"admin", "vpn", "passwall", "clear_all_nodes"}, call("clear_all_nodes")).leaf = true
-	entry({"admin", "vpn", "passwall", "delete_select_nodes"}, call("delete_select_nodes")).leaf = true
-	entry({"admin", "vpn", "passwall", "update_rules"}, call("update_rules")).leaf = true
-	entry({"admin", "vpn", "passwall", "luci_check"}, call("luci_check")).leaf = true
-	entry({"admin", "vpn", "passwall", "luci_update"}, call("luci_update")).leaf = true
-	entry({"admin", "vpn", "passwall", "kcptun_check"}, call("kcptun_check")).leaf = true
-	entry({"admin", "vpn", "passwall", "kcptun_update"}, call("kcptun_update")).leaf = true
-	entry({"admin", "vpn", "passwall", "brook_check"}, call("brook_check")).leaf = true
-	entry({"admin", "vpn", "passwall", "brook_update"}, call("brook_update")).leaf = true
-	entry({"admin", "vpn", "passwall", "v2ray_check"}, call("v2ray_check")).leaf = true
-	entry({"admin", "vpn", "passwall", "v2ray_update"}, call("v2ray_update")).leaf = true
-	entry({"admin", "vpn", "passwall", "trojan_go_check"}, call("trojan_go_check")).leaf = true
-	entry({"admin", "vpn", "passwall", "trojan_go_update"}, call("trojan_go_update")).leaf = true
+	entry({"admin", "services", "passwall", "server_user_status"}, call("server_user_status")).leaf = true
+	entry({"admin", "services", "passwall", "server_get_log"}, call("server_get_log")).leaf = true
+	entry({"admin", "services", "passwall", "server_clear_log"}, call("server_clear_log")).leaf = true
+	entry({"admin", "services", "passwall", "link_append_temp"}, call("link_append_temp")).leaf = true
+	entry({"admin", "services", "passwall", "link_load_temp"}, call("link_load_temp")).leaf = true
+	entry({"admin", "services", "passwall", "link_clear_temp"}, call("link_clear_temp")).leaf = true
+	entry({"admin", "services", "passwall", "link_add_node"}, call("link_add_node")).leaf = true
+	entry({"admin", "services", "passwall", "get_log"}, call("get_log")).leaf = true
+	entry({"admin", "services", "passwall", "clear_log"}, call("clear_log")).leaf = true
+	entry({"admin", "services", "passwall", "status"}, call("status")).leaf = true
+	entry({"admin", "services", "passwall", "socks_status"}, call("socks_status")).leaf = true
+	entry({"admin", "services", "passwall", "connect_status"}, call("connect_status")).leaf = true
+	entry({"admin", "services", "passwall", "check_port"}, call("check_port")).leaf = true
+	entry({"admin", "services", "passwall", "ping_node"}, call("ping_node")).leaf = true
+	entry({"admin", "services", "passwall", "set_node"}, call("set_node")).leaf = true
+	entry({"admin", "services", "passwall", "copy_node"}, call("copy_node")).leaf = true
+	entry({"admin", "services", "passwall", "clear_all_nodes"}, call("clear_all_nodes")).leaf = true
+	entry({"admin", "services", "passwall", "delete_select_nodes"}, call("delete_select_nodes")).leaf = true
+	entry({"admin", "services", "passwall", "update_rules"}, call("update_rules")).leaf = true
+	entry({"admin", "services", "passwall", "luci_check"}, call("luci_check")).leaf = true
+	entry({"admin", "services", "passwall", "luci_update"}, call("luci_update")).leaf = true
+	entry({"admin", "services", "passwall", "kcptun_check"}, call("kcptun_check")).leaf = true
+	entry({"admin", "services", "passwall", "kcptun_update"}, call("kcptun_update")).leaf = true
+	entry({"admin", "services", "passwall", "brook_check"}, call("brook_check")).leaf = true
+	entry({"admin", "services", "passwall", "brook_update"}, call("brook_update")).leaf = true
+	entry({"admin", "services", "passwall", "v2ray_check"}, call("v2ray_check")).leaf = true
+	entry({"admin", "services", "passwall", "v2ray_update"}, call("v2ray_update")).leaf = true
+	entry({"admin", "services", "passwall", "trojan_go_check"}, call("trojan_go_check")).leaf = true
+	entry({"admin", "services", "passwall", "trojan_go_update"}, call("trojan_go_update")).leaf = true
 end
 
 local function http_write_json(content)
@@ -72,12 +72,12 @@ end
 
 function reset_config()
 	luci.sys.call('[ -f "/usr/share/passwall/config.default" ] && cp -f /usr/share/passwall/config.default /etc/config/passwall && /etc/init.d/passwall reload')
-	luci.http.redirect(luci.dispatcher.build_url("admin", "vpn", "passwall"))
+	luci.http.redirect(luci.dispatcher.build_url("admin", "services", "passwall"))
 end
 
 function show_menu()
 	luci.sys.call("touch /etc/config/passwall_show")
-	luci.http.redirect(luci.dispatcher.build_url("admin", "vpn", "passwall"))
+	luci.http.redirect(luci.dispatcher.build_url("admin", "services", "passwall"))
 end
 
 function hide_menu()
@@ -200,7 +200,7 @@ function set_node()
 	ucic:set(appname, "@global[0]", protocol .. "_node" .. number, section)
 	ucic:commit(appname)
 	luci.sys.call("/etc/init.d/passwall restart > /dev/null 2>&1 &")
-	luci.http.redirect(luci.dispatcher.build_url("admin", "vpn", "passwall", "log"))
+	luci.http.redirect(luci.dispatcher.build_url("admin", "services", "passwall", "log"))
 end
 
 function copy_node()

--- a/lienol/luci-app-passwall/luasrc/model/cbi/passwall/node_config.lua
+++ b/lienol/luci-app-passwall/luasrc/model/cbi/passwall/node_config.lua
@@ -66,7 +66,7 @@ local encrypt_methods_ss_aead = {
 }
 
 m = Map(appname, translate("Node Config"))
-m.redirect = d.build_url("admin", "vpn", appname)
+m.redirect = d.build_url("admin", "services", appname)
 
 s = m:section(NamedSection, arg[1], "nodes", "")
 s.addremove = false

--- a/lienol/luci-app-passwall/luasrc/model/cbi/passwall/node_list.lua
+++ b/lienol/luci-app-passwall/luasrc/model/cbi/passwall/node_list.lua
@@ -38,7 +38,7 @@ s = m:section(TypedSection, "nodes")
 s.anonymous = true
 s.addremove = true
 s.template = "cbi/tblsection"
-s.extedit = d.build_url("admin", "vpn", appname, "node_config", "%s")
+s.extedit = d.build_url("admin", "services", appname, "node_config", "%s")
 function s.create(e, t)
     local uuid = _api.gen_uuid()
     t = uuid
@@ -49,7 +49,7 @@ end
 function s.remove(e, t)
     s.map.proceed = true
     s.map:del(t)
-    luci.http.redirect(d.build_url("admin", "vpn", appname, "node_list"))
+    luci.http.redirect(d.build_url("admin", "services", appname, "node_list"))
 end
 
 if m:get("@global_other[0]", "show_group") == "1" then

--- a/lienol/luci-app-passwall/luasrc/model/cbi/passwall/node_subscribe.lua
+++ b/lienol/luci-app-passwall/luasrc/model/cbi/passwall/node_subscribe.lua
@@ -36,7 +36,7 @@ o = s:option(Button, "_update", translate("Manual subscription"))
 o.inputstyle = "apply"
 function o.write(e, e)
     luci.sys.call("lua /usr/share/" .. appname .. "/subscribe.lua start log > /dev/null 2>&1 &")
-    luci.http.redirect(luci.dispatcher.build_url("admin", "vpn", appname, "log"))
+    luci.http.redirect(luci.dispatcher.build_url("admin", "services", appname, "log"))
 end
 
 ---- Subscribe Delete All
@@ -44,7 +44,7 @@ o = s:option(Button, "_stop", translate("Delete All Subscribe Node"))
 o.inputstyle = "remove"
 function o.write(e, e)
     luci.sys.call("lua /usr/share/" .. appname .. "/subscribe.lua truncate log > /dev/null 2>&1 &")
-    luci.http.redirect(luci.dispatcher.build_url("admin", "vpn", appname, "log"))
+    luci.http.redirect(luci.dispatcher.build_url("admin", "services", appname, "log"))
 end
 
 filter_enabled = s:option(Flag, "filter_enabled", translate("Filter keyword switch"), translate("When checked, below options can only be take effect."))

--- a/lienol/luci-app-passwall/luasrc/model/cbi/passwall/rule.lua
+++ b/lienol/luci-app-passwall/luasrc/model/cbi/passwall/rule.lua
@@ -54,7 +54,7 @@ s = m:section(TypedSection, "shunt_rules", "V2ray" .. translate("Shunt") .. tran
 s.template = "cbi/tblsection"
 s.anonymous = false
 s.addremove = true
-s.extedit = d.build_url("admin", "vpn", appname, "shunt_rules", "%s")
+s.extedit = d.build_url("admin", "services", appname, "shunt_rules", "%s")
 function s.create(e, t)
     TypedSection.create(e, t)
     luci.http.redirect(e.extedit:format(t))

--- a/lienol/luci-app-passwall/luasrc/model/cbi/passwall/server/index.lua
+++ b/lienol/luci-app-passwall/luasrc/model/cbi/passwall/server/index.lua
@@ -15,7 +15,7 @@ t = m:section(TypedSection, "user", translate("Users Manager"))
 t.anonymous = true
 t.addremove = true
 t.template = "cbi/tblsection"
-t.extedit = d.build_url("admin", "vpn", "passwall", "server_user", "%s")
+t.extedit = d.build_url("admin", "services", "passwall", "server_user", "%s")
 function t.create(e, t)
     local uuid = _api.gen_uuid()
     t = uuid
@@ -25,7 +25,7 @@ end
 function t.remove(e, t)
     e.map.proceed = true
     e.map:del(t)
-    luci.http.redirect(d.build_url("admin", "vpn", "passwall", "server"))
+    luci.http.redirect(d.build_url("admin", "services", "passwall", "server"))
 end
 
 e = t:option(Flag, "enable", translate("Enable"))

--- a/lienol/luci-app-passwall/luasrc/model/cbi/passwall/server/user.lua
+++ b/lienol/luci-app-passwall/luasrc/model/cbi/passwall/server/user.lua
@@ -50,7 +50,7 @@ local encrypt_methods_ss_aead = {
 }
 
 map = Map("passwall_server", translate("Server Config"))
-map.redirect = d.build_url("admin", "vpn", "passwall", "server")
+map.redirect = d.build_url("admin", "services", "passwall", "server")
 
 s = map:section(NamedSection, arg[1], "user", "")
 s.addremove = false

--- a/lienol/luci-app-passwall/luasrc/model/cbi/passwall/shunt_rules.lua
+++ b/lienol/luci-app-passwall/luasrc/model/cbi/passwall/shunt_rules.lua
@@ -2,7 +2,7 @@ local d = require "luci.dispatcher"
 local appname = "passwall"
 
 m = Map(appname, "V2ray" .. translate("Shunt") .. translate("Rule"))
-m.redirect = d.build_url("admin", "vpn", appname)
+m.redirect = d.build_url("admin", "services", appname)
 
 s = m:section(NamedSection, arg[1], "shunt_rules", "")
 s.addremove = false

--- a/lienol/luci-app-passwall/luasrc/view/passwall/global/footer.htm
+++ b/lienol/luci-app-passwall/luasrc/view/passwall/global/footer.htm
@@ -3,7 +3,7 @@
 	var _status = document.getElementsByClassName('_status');
 	for (var i = 0; i < _status.length; i++) {
 		var id = _status[i].getAttribute("socks_id");
-		XHR.get('<%=url([[admin]], [[vpn]], [[passwall]], [[socks_status]])%>', {
+		XHR.get('<%=url([[admin]], [[services]], [[passwall]], [[socks_status]])%>', {
 				index: i,
 				id: id
 			},

--- a/lienol/luci-app-passwall/luasrc/view/passwall/global/status.htm
+++ b/lienol/luci-app-passwall/luasrc/view/passwall/global/status.htm
@@ -241,7 +241,7 @@ https://github.com/pure-css/pure/blob/master/LICENSE.md
 			document.getElementsByTagName('img')[i].setAttribute("oncontextmenu","return false;");
 			document.getElementsByTagName('img')[i].setAttribute("ondragstart","return false;");
 		}
-		XHR.poll(5, '<%=dsp.build_url("admin/vpn/passwall/status")%>', null,
+		XHR.poll(5, '<%=dsp.build_url("admin/services/passwall/status")%>', null,
 			function (x, data) {
 				var status_dns = document.getElementById('status_dns');
 				var status_haproxy = document.getElementById('status_haproxy');
@@ -334,7 +334,7 @@ https://github.com/pure-css/pure/blob/master/LICENSE.md
 				div.removeAttribute('onclick');
 				s.innerHTML = '<%:Check...%>';
 				var sendDate = (new Date()).getTime();
-				XHR.get('<%=dsp.build_url("admin/vpn/passwall/connect_status")%>', {
+				XHR.get('<%=dsp.build_url("admin/services/passwall/connect_status")%>', {
 						type: type,
 						url : url
 					},
@@ -369,7 +369,7 @@ https://github.com/pure-css/pure/blob/master/LICENSE.md
 			if (s) {
 				dom.removeAttribute('onclick');
 				s.innerHTML = '<%:Check...%>';
-				XHR.get('<%=dsp.build_url("admin/vpn/passwall/check_port")%>', null,
+				XHR.get('<%=dsp.build_url("admin/services/passwall/check_port")%>', null,
 					function(x, rv) {
 						if (rv.ret) {
 							s.innerHTML = rv.ret;

--- a/lienol/luci-app-passwall/luasrc/view/passwall/global/status2.htm
+++ b/lienol/luci-app-passwall/luasrc/view/passwall/global/status2.htm
@@ -169,7 +169,7 @@ local status_show_ip111 = api.uci_get_type("global_other", "status_show_ip111", 
 	var kcptun_status = document.getElementById('_kcptun_status');
 	var baidu_status = document.getElementById('_baidu_status');
 	var google_status = document.getElementById('_google_status');
-	XHR.poll(3, '<%=dsp.build_url("admin/vpn/passwall/status")%>', null,
+	XHR.poll(3, '<%=dsp.build_url("admin/services/passwall/status")%>', null,
 		function(x, json) {
 			if (x && x.status == 200) {
 				var tcp_node_status = document.getElementById('_tcp_node_status');
@@ -247,7 +247,7 @@ local status_show_ip111 = api.uci_get_type("global_other", "status_show_ip111", 
 		btn.disabled = true;
 		btn.value = '<%:Check...%>';
 		var sendDate = (new Date()).getTime();
-		XHR.get('<%=dsp.build_url("admin/vpn/passwall/connect_status")%>', {
+		XHR.get('<%=dsp.build_url("admin/services/passwall/connect_status")%>', {
 				type: type,
 				url: url
 			},
@@ -286,7 +286,7 @@ local status_show_ip111 = api.uci_get_type("global_other", "status_show_ip111", 
 	function check_port(btn) {
 		btn.disabled = true;
 		btn.value = '<%:Check...%>';
-		XHR.get('<%=dsp.build_url("admin/vpn/passwall/check_port")%>', null,
+		XHR.get('<%=dsp.build_url("admin/services/passwall/check_port")%>', null,
 			function(x, rv) {
 				var s = document.getElementById('_node_status');
 				if (s) {

--- a/lienol/luci-app-passwall/luasrc/view/passwall/global/tips.htm
+++ b/lienol/luci-app-passwall/luasrc/view/passwall/global/tips.htm
@@ -2,10 +2,10 @@
 		<div>
 		<%:You can use load balancing for failover.%>
 		<br />
-		<%:Restore the default configuration method. Input example in the address bar:%> http://192.168.1.1/cgi-bin/luci/admin/vpn/passwall/reset_config
+		<%:Restore the default configuration method. Input example in the address bar:%> http://192.168.1.1/cgi-bin/luci/admin/services/passwall/reset_config
 		<br />
-		<%:Hide menu method, input example in the address bar:%> http://192.168.1.1/cgi-bin/luci/admin/vpn/passwall/hide
+		<%:Hide menu method, input example in the address bar:%> http://192.168.1.1/cgi-bin/luci/admin/services/passwall/hide
 		<br />
-		<%:After the hidden to the display, input example in the address bar:%> http://192.168.1.1/cgi-bin/luci/admin/vpn/passwall/show
+		<%:After the hidden to the display, input example in the address bar:%> http://192.168.1.1/cgi-bin/luci/admin/services/passwall/show
 	</div>
 </div>

--- a/lienol/luci-app-passwall/luasrc/view/passwall/haproxy/status.htm
+++ b/lienol/luci-app-passwall/luasrc/view/passwall/haproxy/status.htm
@@ -1,7 +1,7 @@
 <p id="_status"></p>
 
 <script type="text/javascript">//<![CDATA[
-	XHR.poll(3, '<%=url([[admin]], [[vpn]], [[passwall]], [[status]])%>', null,
+	XHR.poll(3, '<%=url([[admin]], [[services]], [[passwall]], [[status]])%>', null,
 		function(x, json) {
 			if (x && x.status == 200) {
 				var _status = document.getElementById('_status');

--- a/lienol/luci-app-passwall/luasrc/view/passwall/log/log.htm
+++ b/lienol/luci-app-passwall/luasrc/view/passwall/log/log.htm
@@ -1,7 +1,7 @@
 <script type="text/javascript">
 	//<![CDATA[
 	function clearlog(btn) {
-		XHR.get('<%=url([[admin]], [[vpn]], [[passwall]], [[clear_log]])%>', null,
+		XHR.get('<%=url([[admin]], [[services]], [[passwall]], [[clear_log]])%>', null,
 			function(x, data) {
 				if(x && x.status == 200) {
 					var log_textarea = document.getElementById('log_textarea');
@@ -11,7 +11,7 @@
 			}
 		);
 	}
-	XHR.poll(2, '<%=url([[admin]], [[vpn]], [[passwall]], [[get_log]])%>', null,
+	XHR.poll(2, '<%=url([[admin]], [[services]], [[passwall]], [[get_log]])%>', null,
 		function(x, data) {
 			if(x && x.status == 200) {
 				var log_textarea = document.getElementById('log_textarea');

--- a/lienol/luci-app-passwall/luasrc/view/passwall/node_list/link_add_node.htm
+++ b/lienol/luci-app-passwall/luasrc/view/passwall/node_list/link_add_node.htm
@@ -25,10 +25,10 @@ local dsp = require "luci.dispatcher"
 	//<![CDATA[
 	function link_clear_temp() {
 		if (confirm('<%:Are you sure to clear all cached links?%>') == true){
-			XHR.get('<%=dsp.build_url("admin/vpn/passwall/link_clear_temp")%>', null,
+			XHR.get('<%=dsp.build_url("admin/services/passwall/link_clear_temp")%>', null,
 			function(x, data) {
 				if(x && x.status == 200) {
-					window.location.href = '<%=dsp.build_url("admin/vpn/passwall/node_list")%>';
+					window.location.href = '<%=dsp.build_url("admin/services/passwall/node_list")%>';
 				}
 				else {
 					alert("<%:Error%>");
@@ -39,7 +39,7 @@ local dsp = require "luci.dispatcher"
 
 	function link_load_temp() {
 		var inputer = document.getElementById("nodes_link");
-		XHR.get('<%=dsp.build_url("admin/vpn/passwall/link_load_temp")%>', null,
+		XHR.get('<%=dsp.build_url("admin/services/passwall/link_load_temp")%>', null,
 		function(x, data) {
 			if(x.readyState === 4 && x.status === 200) {
 				try {
@@ -60,12 +60,12 @@ local dsp = require "luci.dispatcher"
 
 	function ajax_add_node(link) {
 		if (link) {
-			XHR.get('<%=dsp.build_url("admin/vpn/passwall/link_add_node")%>', {
+			XHR.get('<%=dsp.build_url("admin/services/passwall/link_add_node")%>', {
 				'link': link
 			},
 			function(x, data) {
 				if(x && x.status == 200) {
-					window.location.href = '<%=dsp.build_url("admin/vpn/passwall/node_list")%>';
+					window.location.href = '<%=dsp.build_url("admin/services/passwall/node_list")%>';
 				}
 				else {
 					alert("<%:Error%>");
@@ -100,10 +100,10 @@ local dsp = require "luci.dispatcher"
 	
 	function clear_all_nodes() {
 		if (confirm('<%:Are you sure to clear all nodes?%>') == true){
-			XHR.get('<%=dsp.build_url("admin/vpn/passwall/clear_all_nodes")%>', null,
+			XHR.get('<%=dsp.build_url("admin/services/passwall/clear_all_nodes")%>', null,
 			function(x, data) {
 				if(x && x.status == 200) {
-					window.location.href = '<%=dsp.build_url("admin/vpn/passwall/node_list")%>';
+					window.location.href = '<%=dsp.build_url("admin/services/passwall/node_list")%>';
 				}
 				else {
 					alert("<%:Error%>");

--- a/lienol/luci-app-passwall/luasrc/view/passwall/node_list/link_share_man.htm
+++ b/lienol/luci-app-passwall/luasrc/view/passwall/node_list/link_share_man.htm
@@ -77,7 +77,7 @@ local dsp = require "luci.dispatcher"
 	}
 
 	function link_append_temp(link) {
-		XHR.get('<%=dsp.build_url("admin/vpn/passwall/link_append_temp")%>', {
+		XHR.get('<%=dsp.build_url("admin/services/passwall/link_append_temp")%>', {
 			'link': link
 		},
 		function(x, data) {

--- a/lienol/luci-app-passwall/luasrc/view/passwall/node_list/node_list.htm
+++ b/lienol/luci-app-passwall/luasrc/view/passwall/node_list/node_list.htm
@@ -173,12 +173,12 @@ table td, .table .td {
 				}
 			}
 			if (confirm('<%:Are you sure to delete select nodes?%>') == true){
-				XHR.get('<%=dsp.build_url("admin/vpn/passwall/delete_select_nodes")%>', {
+				XHR.get('<%=dsp.build_url("admin/services/passwall/delete_select_nodes")%>', {
 					ids: ids.join()
 				},
 				function(x, data) {
 					if(x && x.status == 200) {
-						window.location.href = '<%=dsp.build_url("admin/vpn/passwall/node_list")%>';
+						window.location.href = '<%=dsp.build_url("admin/services/passwall/node_list")%>';
 					}
 					else {
 						alert("<%:Error%>");
@@ -192,7 +192,7 @@ table td, .table .td {
 	
 	function set_node(protocol,number) {
 		if (confirm('<%:Are you sure set to%> ' + protocol.toUpperCase() + "_" + number + '<%:the server?%>')==true){
-			window.location.href = '<%=dsp.build_url("admin/vpn/passwall/set_node")%>?protocol=' + protocol + '&number=' + number + '&section=' + section;
+			window.location.href = '<%=dsp.build_url("admin/services/passwall/set_node")%>?protocol=' + protocol + '&number=' + number + '&section=' + section;
 		}
 	}
 	
@@ -224,7 +224,7 @@ table td, .table .td {
 	function ping_node(cbi_id, dom) {
 		var full = get_address_full(cbi_id);
 		if (full != null) {
-			XHR.get('<%=dsp.build_url("admin/vpn/passwall/ping_node")%>', {
+			XHR.get('<%=dsp.build_url("admin/services/passwall/ping_node")%>', {
 					address: full.address,
 					port: full.port
 				},
@@ -277,7 +277,7 @@ table td, .table .td {
 		return new Promise((res) => {
 			const dom = nodes[index];
 			if (!dom) res()
-			ajax.post('<%=dsp.build_url("admin/vpn/passwall/ping_node")%>', {
+			ajax.post('<%=dsp.build_url("admin/services/passwall/ping_node")%>', {
 					index: dom.indexs,
 					address: dom.address,
 					port: dom.port
@@ -333,7 +333,7 @@ table td, .table .td {
 		var indexs = nodes[index].indexs;
 		var address = nodes[index].address;
 		var port = nodes[index].port;
-		ajax.post('<%=dsp.build_url("admin/vpn/passwall/ping_node")%>', {
+		ajax.post('<%=dsp.build_url("admin/services/passwall/ping_node")%>', {
 				index: indexs,
 				address: address,
 				port: port

--- a/lienol/luci-app-passwall/luasrc/view/passwall/rule/brook_version.htm
+++ b/lienol/luci-app-passwall/luasrc/view/passwall/rule/brook_version.htm
@@ -71,7 +71,7 @@ local brook_version = require "luci.model.cbi.passwall.api.api".get_brook_versio
 
 		var ckeckDetailElm = document.getElementById(btn.id + '-detail');
 
-		XHR.get('<%=url([[admin]], [[vpn]], [[passwall]], [[brook_check]])%>', {
+		XHR.get('<%=url([[admin]], [[services]], [[passwall]], [[brook_check]])%>', {
 			token: tokenStr,
 			arch: ''
 		}, function(x,json) {
@@ -111,7 +111,7 @@ local brook_version = require "luci.model.cbi.passwall.api.api".get_brook_versio
 
 		addPageNotice_brook();
 
-		var brookUpdateUrl = '<%=url([[admin]], [[vpn]], [[passwall]], [[brook_update]])%>';
+		var brookUpdateUrl = '<%=url([[admin]], [[services]], [[passwall]], [[brook_update]])%>';
 		// Download file
 		XHR.get(brookUpdateUrl, {
 			token: tokenStr,

--- a/lienol/luci-app-passwall/luasrc/view/passwall/rule/kcptun_version.htm
+++ b/lienol/luci-app-passwall/luasrc/view/passwall/rule/kcptun_version.htm
@@ -71,7 +71,7 @@ local kcptun_version = require "luci.model.cbi.passwall.api.api".get_kcptun_vers
 
 		var ckeckDetailElm = document.getElementById(btn.id + '-detail');
 
-		XHR.get('<%=url([[admin]], [[vpn]], [[passwall]], [[kcptun_check]])%>', {
+		XHR.get('<%=url([[admin]], [[services]], [[passwall]], [[kcptun_check]])%>', {
 			token: tokenStr,
 			arch: ''
 		}, function(x,json) {
@@ -111,7 +111,7 @@ local kcptun_version = require "luci.model.cbi.passwall.api.api".get_kcptun_vers
 
 		addPageNotice_kcptun();
 
-		var kcptunUpdateUrl = '<%=url([[admin]], [[vpn]], [[passwall]], [[kcptun_update]])%>';
+		var kcptunUpdateUrl = '<%=url([[admin]], [[services]], [[passwall]], [[kcptun_update]])%>';
 		// Download file
 		XHR.get(kcptunUpdateUrl, {
 			token: tokenStr,

--- a/lienol/luci-app-passwall/luasrc/view/passwall/rule/rule_version.htm
+++ b/lienol/luci-app-passwall/luasrc/view/passwall/rule/rule_version.htm
@@ -25,12 +25,12 @@ local chnlist_update = api.uci_get_type("global_rules", "chnlist_update", "1") =
 				checkBoxList.push(dom.name);　　
 			}
 		}
-		XHR.get('<%=url([[admin]], [[vpn]], [[passwall]], [[update_rules]])%>', {
+		XHR.get('<%=url([[admin]], [[services]], [[passwall]], [[update_rules]])%>', {
 				update: checkBoxList
 			},
 			function(x, data) {
 				if(x && x.status == 200) {
-					window.location.href = '<%=url([[admin]], [[vpn]], [[passwall]], [[log]])%>';
+					window.location.href = '<%=url([[admin]], [[services]], [[passwall]], [[log]])%>';
 				} else {
 					alert("<%:Error%>");
 					btn.disabled = false;

--- a/lienol/luci-app-passwall/luasrc/view/passwall/rule/trojan_go_version.htm
+++ b/lienol/luci-app-passwall/luasrc/view/passwall/rule/trojan_go_version.htm
@@ -71,7 +71,7 @@ local trojan_go_version = require "luci.model.cbi.passwall.api.api".get_trojan_g
 
 		var ckeckDetailElm = document.getElementById(btn.id + '-detail');
 
-		XHR.get('<%=url([[admin]], [[vpn]], [[passwall]], [[trojan_go_check]])%>', {
+		XHR.get('<%=url([[admin]], [[services]], [[passwall]], [[trojan_go_check]])%>', {
 			token: tokenStr,
 			arch: ''
 		}, function(x,json) {
@@ -111,7 +111,7 @@ local trojan_go_version = require "luci.model.cbi.passwall.api.api".get_trojan_g
 
 		addPageNotice_trojan();
 
-		var trojanUpdateUrl = '<%=url([[admin]], [[vpn]], [[passwall]], [[trojan_go_update]])%>';
+		var trojanUpdateUrl = '<%=url([[admin]], [[services]], [[passwall]], [[trojan_go_update]])%>';
 		// Download file
 		XHR.get(trojanUpdateUrl, {
 			token: tokenStr,

--- a/lienol/luci-app-passwall/luasrc/view/passwall/rule/v2ray_version.htm
+++ b/lienol/luci-app-passwall/luasrc/view/passwall/rule/v2ray_version.htm
@@ -71,7 +71,7 @@ local v2ray_version = require "luci.model.cbi.passwall.api.api".get_v2ray_versio
 
 		var ckeckDetailElm = document.getElementById(btn.id + '-detail');
 
-		XHR.get('<%=url([[admin]], [[vpn]], [[passwall]], [[v2ray_check]])%>', {
+		XHR.get('<%=url([[admin]], [[services]], [[passwall]], [[v2ray_check]])%>', {
 			token: tokenStr,
 			arch: ''
 		}, function(x,json) {
@@ -111,7 +111,7 @@ local v2ray_version = require "luci.model.cbi.passwall.api.api".get_v2ray_versio
 
 		addPageNotice_v2ray();
 
-		var v2rayUpdateUrl = '<%=url([[admin]], [[vpn]], [[passwall]], [[v2ray_update]])%>';
+		var v2rayUpdateUrl = '<%=url([[admin]], [[services]], [[passwall]], [[v2ray_update]])%>';
 		// Download file
 		XHR.get(v2rayUpdateUrl, {
 			token: tokenStr,

--- a/lienol/luci-app-passwall/luasrc/view/passwall/server/log.htm
+++ b/lienol/luci-app-passwall/luasrc/view/passwall/server/log.htm
@@ -1,7 +1,7 @@
 <script type="text/javascript">
 	//<![CDATA[
 	function clear_log(btn) {
-		XHR.get('<%=url([[admin]], [[vpn]], [[passwall]], [[server_clear_log]])%>', null,
+		XHR.get('<%=url([[admin]], [[services]], [[passwall]], [[server_clear_log]])%>', null,
 			function(x, data) {
 				if(x && x.status == 200) {
 					var log_textarea = document.getElementById('log_textarea');
@@ -11,7 +11,7 @@
 			}
 		);
 	}
-	XHR.poll(3, '<%=url([[admin]], [[vpn]], [[passwall]], [[server_get_log]])%>', null,
+	XHR.poll(3, '<%=url([[admin]], [[services]], [[passwall]], [[server_get_log]])%>', null,
 		function(x, data) {
 			if(x && x.status == 200) {
 				var log_textarea = document.getElementById('log_textarea');

--- a/lienol/luci-app-passwall/luasrc/view/passwall/server/users_list_status.htm
+++ b/lienol/luci-app-passwall/luasrc/view/passwall/server/users_list_status.htm
@@ -4,7 +4,7 @@
 	for(var i = 0; i < _users_status.length; i++) {
 		var id = _users_status[i].parentElement.parentElement.parentElement.id;
 		id = id.substr(id.lastIndexOf("-") + 1);
-		XHR.poll(1,'<%=url([[admin]], [[vpn]], [[passwall]], [[server_user_status]])%>', {
+		XHR.poll(1,'<%=url([[admin]], [[services]], [[passwall]], [[server_user_status]])%>', {
 				index: i,
 				id: id
 			},


### PR DESCRIPTION
passwall是一款非常优秀的openwrt代理插件，但是个人认为其并不属于vpn的范畴，希望可以移动到“services”分类。(修改后，目前使用正常)