### PR TITLE
rules for name servers follow main TCP proxy modes(testing purpose)

### DIFF
--- a/lienol/luci-app-passwall/luasrc/model/cbi/passwall/acl.lua
+++ b/lienol/luci-app-passwall/luasrc/model/cbi/passwall/acl.lua
@@ -114,8 +114,8 @@ o:value("default", translate("Default"))
 o:value("disable", translate("No Proxy"))
 o:value("global", translate("Global Proxy"))
 o:value("gfwlist", translate("GFW List"))
-o:value("chnroute", translate("China WhiteList"))
-o:value("returnhome", translate("Return Home"))
+o:value("chnroute", translate("Not China List"))
+o:value("returnhome", translate("China List"))
 
 ---- UDP Proxy Mode
 o = s:option(ListValue, "udp_proxy_mode", "UDP" .. translate("Proxy Mode"))
@@ -125,8 +125,8 @@ o:value("default", translate("Default"))
 o:value("disable", translate("No Proxy"))
 o:value("global", translate("Global Proxy"))
 o:value("gfwlist", translate("GFW List"))
-o:value("chnroute", translate("Game Mode") .. "（" .. translate("China WhiteList") .. "）")
-o:value("returnhome", translate("Return Home"))
+o:value("chnroute", translate("Game Mode") .. "（" .. translate("Not China List") .. "）")
+o:value("returnhome", translate("China List"))
 
 ---- TCP No Redir Ports
 o = s:option(Value, "tcp_no_redir_ports", translate("TCP No Redir Ports"))

--- a/lienol/luci-app-passwall/luasrc/model/cbi/passwall/global.lua
+++ b/lienol/luci-app-passwall/luasrc/model/cbi/passwall/global.lua
@@ -57,14 +57,13 @@ else
     m:append(Template(appname .. "/global/status2"))
 end
 
--- [[ Global Settings ]]--
-s = m:section(TypedSection, "global")
+s = m:section(TypedSection, "global", translate("Main Settings"))
 s.anonymous = true
 s.addremove = false
 
-s:tab("Main", translate("Main Settings"))
+s:tab("Main", translate("Main"))
 
----- Main switch
+-- [[ Global Settings ]]--
 o = s:taboption("Main", Flag, "enabled", translate("Main switch"))
 o.rmempty = false
 
@@ -73,7 +72,7 @@ local tcp_node_num = tonumber(m:get("@global_other[0]", "tcp_node_num") or 1)
 for i = 1, tcp_node_num, 1 do
     if i == 1 then
         o = s:taboption("Main", ListValue, "tcp_node" .. i, translate("TCP Node"))
-        -- o.description = translate("For used to surf the Internet.")
+        o.description = translate("For proxy specific list.")
     else
         o = s:taboption("Main", ListValue, "tcp_node" .. i,
                      translate("TCP Node") .. " " .. i)
@@ -87,7 +86,7 @@ local udp_node_num = tonumber(m:get("@global_other[0]", "udp_node_num") or 1)
 for i = 1, udp_node_num, 1 do
     if i == 1 then
         o = s:taboption("Main", ListValue, "udp_node" .. i, translate("UDP Node"))
-        -- o.description = translate("For Game Mode or DNS resolution and more.") .. translate("The selected server will not use Kcptun.")
+        o.description = translate("For proxy game network, DNS hijack etc.") .. translate(" The selected server will not use Kcptun.")
         o:value("nil", translate("Close"))
         o:value("tcp", translate("Same as the tcp node"))
         o:value("tcp_", translate("Same as the tcp node") .. "（" .. translate("New process") .. "）")
@@ -99,26 +98,10 @@ for i = 1, udp_node_num, 1 do
     for k, v in pairs(nodes_table) do o:value(v.id, v.remarks) end
 end
 
-s:tab("DNS", translate("DNS Settings"))
-
-o = s:taboption("DNS", Value, "up_china_dns", translate("China DNS Server") .. "(UDP)")
--- o.description = translate("If you want to work with other DNS acceleration services, use the default.<br />Only use two at most, english comma separation, If you do not fill in the # and the following port, you are using port 53.")
-o.default = "default"
-o:value("default", translate("Default"))
-o:value("dnsbyisp", translate("dnsbyisp"))
-o:value("223.5.5.5", "223.5.5.5 (" .. translate("Ali") .. "DNS)")
-o:value("223.6.6.6", "223.6.6.6 (" .. translate("Ali") .. "DNS)")
-o:value("114.114.114.114", "114.114.114.114 (114DNS)")
-o:value("114.114.115.115", "114.114.115.115 (114DNS)")
-o:value("119.29.29.29", "119.29.29.29 (DNSPOD DNS)")
-o:value("182.254.116.116", "182.254.116.116 (DNSPOD DNS)")
-o:value("1.2.4.8", "1.2.4.8 (CNNIC DNS)")
-o:value("210.2.4.8", "210.2.4.8 (CNNIC DNS)")
-o:value("180.76.76.76", "180.76.76.76 (" .. translate("Baidu") .. "DNS)")
+s:tab("DNS", translate("DNS"))
 
 ---- DNS Forward Mode
-o = s:taboption("DNS", Value, "dns_mode", translate("DNS Mode"))
--- o.description = translate("if has problem, please try another mode.<br />if you use no patterns are used, DNS of wan will be used by default as upstream of dnsmasq.")
+o = s:taboption("DNS", Value, "dns_mode", translate("Filter Mode"))
 o.rmempty = false
 o:reset_values()
 if api.is_finded("chinadns-ng") then
@@ -130,56 +113,59 @@ end
 if api.is_finded("dns2socks") then
     o:value("dns2socks", "dns2socks")
 end
-o:value("nonuse", translate("No patterns are used"))
+o:value("nonuse", translate("No Filter"))
+
+o = s:taboption("DNS", Value, "up_china_dns", translate("Resolver For Local/WhiteList Domains") .. "(UDP)")
+o.description = translate("Forced to local filter mode on 'Not China List' mode<br />IP:Port mode acceptable, multi value split with english comma.")
+o.default = "default"
+o:value("default", translate("Default"))
+o:value("223.5.5.5", "223.5.5.5 (" .. translate("Ali") .. "DNS)")
+o:value("223.6.6.6", "223.6.6.6 (" .. translate("Ali") .. "DNS)")
+o:value("114.114.114.114", "114.114.114.114 (114DNS)")
+o:value("114.114.115.115", "114.114.115.115 (114DNS)")
+o:value("119.29.29.29", "119.29.29.29 (DNSPOD DNS)")
+o:value("182.254.116.116", "182.254.116.116 (DNSPOD DNS)")
+o:value("1.2.4.8", "1.2.4.8 (CNNIC DNS)")
+o:value("210.2.4.8", "210.2.4.8 (CNNIC DNS)")
+o:value("180.76.76.76", "180.76.76.76 (" .. translate("Baidu") .. "DNS)")
 
 o = s:taboption("DNS", ListValue, "up_trust_pdnsd_dns",
-             translate("Upstream trust DNS Server for Pdnsd") .. "(TCP)")
+             translate("Resolver For The List Proxied") .. "(TCP)")
 -- o.description = translate("You can use other resolving DNS services as trusted DNS, Example: dns2socks, dns-forwarder... 127.0.0.1#5353<br />Only use two at most, english comma separation, If you do not fill in the # and the following port, you are using port 53.")
 o.default = ""
 if api.is_finded("pdnsd") then
-    o:value("", "pdnsd + " .. translate("Use TCP Node Resolve DNS"))
+    o:value("", "pdnsd + " .. translate("Access Filtered DNS By ") .. translate("TCP Node"))
 end
 if api.is_finded("dns2socks") then
     o:value("dns2socks", "dns2socks")
 end
 o:depends("dns_mode", "pdnsd")
 
----- Upstream trust DNS Server for ChinaDNS-NG
-o = s:taboption("DNS", ListValue, "up_trust_chinadns_ng_dns",
-             translate("Upstream trust DNS Server for ChinaDNS-NG") .. "(UDP)")
--- o.description = translate("You can use other resolving DNS services as trusted DNS, Example: dns2socks, dns-forwarder... 127.0.0.1#5353<br />Only use two at most, english comma separation, If you do not fill in the # and the following port, you are using port 53.")
+o = s:taboption("DNS", ListValue, "up_trust_chinadns_ng_dns", translate("Resolver For The List Proxied") .. "(UDP)")
 o.default = "pdnsd"
 if api.is_finded("pdnsd") then
-    o:value("pdnsd", "pdnsd + " .. translate("Use TCP Node Resolve DNS"))
+    o:value("pdnsd", "pdnsd, " .. translate("Access Filtered DNS By ") .. translate("TCP Node"))
 end
+o:value("udp", translate("Access Filtered DNS By ") .. translate("UDP Node"))
 if api.is_finded("dns2socks") then
     o:value("dns2socks", "dns2socks")
 end
-o:value("udp", translate("Use UDP Node Resolve DNS"))
 o:depends("dns_mode", "chinadns-ng")
 
----- Use TCP Node Resolve DNS
---[[ if api.is_finded("pdnsd") then
-    o = s:taboption("DNS", Flag, "use_tcp_node_resolve_dns", translate("Use TCP Node Resolve DNS"))
-    o.description = translate("If checked, DNS is resolved using the TCP node.")
-    o.default = 1
-    o:depends("dns_mode", "pdnsd")
-end
---]]
-
-o = s:taboption("DNS", Value, "socks_server", translate("Socks Server"))
+---- Upstream trust DNS Mode for ChinaDNS-NG
+o = s:taboption("DNS", Value, "socks_server", translate("Socks Server"), translate("Make sure socks service is available on this address if 'dns2socks' selected."))
 o.default = ""
+for k, v in pairs(socks_table) do o:value(v.id, v.remarks) end
 o:depends({dns_mode = "dns2socks"})
 o:depends({dns_mode = "chinadns-ng", up_trust_chinadns_ng_dns = "dns2socks"})
 o:depends({dns_mode = "pdnsd", up_trust_pdnsd_dns = "dns2socks"})
-for k, v in pairs(socks_table) do o:value(v.id, v.remarks) end
 
-o = s:taboption("DNS", Flag, "fair_mode", translate("Fair Mode"))
+o = s:taboption("DNS", Flag, "fair_mode", translate("ChinaDNS-NG Fair Mode"))
 o.default = "1"
 o:depends({dns_mode = "chinadns-ng"})
 
 ---- DNS Forward
-o = s:taboption("DNS", Value, "dns_forward", translate("DNS Address"))
+o = s:taboption("DNS", Value, "dns_forward", translate("Filtered DNS(For Proxied Domains)"), translate("IP:Port mode acceptable, the 1st for 'dns2socks' if split with english comma."))
 o.default = "8.8.4.4"
 o:value("8.8.4.4", "8.8.4.4 (Google DNS)")
 o:value("8.8.8.8", "8.8.8.8 (Google DNS)")
@@ -189,17 +175,17 @@ o:depends({dns_mode = "chinadns-ng"})
 o:depends({dns_mode = "dns2socks"})
 o:depends({dns_mode = "pdnsd"})
 
-o = s:taboption("DNS", Flag, "dns_cache", translate("DNS Cache"))
+o = s:taboption("DNS", Flag, "dns_cache", translate("Cache Resolved"))
 o.default = "1"
 o:depends({dns_mode = "chinadns-ng", up_trust_chinadns_ng_dns = "pdnsd"})
 o:depends({dns_mode = "chinadns-ng", up_trust_chinadns_ng_dns = "dns2socks"})
 o:depends({dns_mode = "dns2socks"})
 o:depends({dns_mode = "pdnsd"})
 
-s:tab("Mode", translate("Proxy Mode"))
+s:tab("Proxy", translate("Mode"))
 
 ---- TCP Default Proxy Mode
-o = s:taboption("Mode", ListValue, "tcp_proxy_mode",
+o = s:taboption("Proxy", ListValue, "tcp_proxy_mode",
              "TCP" .. translate("Default") .. translate("Proxy Mode"))
 -- o.description = translate("If not available, try clearing the cache.")
 o.default = "chnroute"
@@ -207,38 +193,38 @@ o.rmempty = false
 o:value("disable", translate("No Proxy"))
 o:value("global", translate("Global Proxy"))
 o:value("gfwlist", translate("GFW List"))
-o:value("chnroute", translate("China WhiteList"))
-o:value("returnhome", translate("Return Home"))
+o:value("chnroute", translate("Not China List"))
+o:value("returnhome", translate("China List"))
 
 ---- UDP Default Proxy Mode
-o = s:taboption("Mode", ListValue, "udp_proxy_mode",
+o = s:taboption("Proxy", ListValue, "udp_proxy_mode",
              "UDP" .. translate("Default") .. translate("Proxy Mode"))
 o.default = "chnroute"
 o.rmempty = false
 o:value("disable", translate("No Proxy"))
 o:value("global", translate("Global Proxy"))
 o:value("gfwlist", translate("GFW List"))
-o:value("chnroute", translate("Game Mode") .. "（" .. translate("China WhiteList") .. "）")
-o:value("returnhome", translate("Return Home"))
+o:value("chnroute", translate("Game Mode") .. "（" .. translate("Not China List") .. "）")
+o:value("returnhome", translate("China List"))
 
 ---- Localhost TCP Proxy Mode
-o = s:taboption("Mode", ListValue, "localhost_tcp_proxy_mode",
+o = s:taboption("Proxy", ListValue, "localhost_tcp_proxy_mode",
              translate("Router Localhost") .. "TCP" .. translate("Proxy Mode"))
 -- o.description = translate("The server client can also use this rule to scientifically surf the Internet.")
 o:value("default", translate("Default"))
 o:value("gfwlist", translate("GFW List"))
-o:value("chnroute", translate("China WhiteList"))
+o:value("chnroute", translate("Not China List"))
 o:value("global", translate("Global Proxy"))
 o.default = "default"
 o.rmempty = false
 
 ---- Localhost UDP Proxy Mode
-o = s:taboption("Mode", ListValue, "localhost_udp_proxy_mode",
+o = s:taboption("Proxy", ListValue, "localhost_udp_proxy_mode",
              translate("Router Localhost") .. "UDP" .. translate("Proxy Mode"))
 o:value("disable", translate("No Proxy"))
 o:value("default", translate("Default"))
 o:value("gfwlist", translate("GFW List"))
-o:value("chnroute", translate("Game Mode") .. "（" .. translate("China WhiteList") .. "）")
+o:value("chnroute", translate("Game Mode") .. "（" .. translate("Not China List") .. "）")
 o:value("global", translate("Global Proxy"))
 o.default = "default"
 o.rmempty = false

--- a/lienol/luci-app-passwall/luasrc/model/cbi/passwall/rule.lua
+++ b/lienol/luci-app-passwall/luasrc/model/cbi/passwall/rule.lua
@@ -14,20 +14,20 @@ o.rmempty = false
 
 ---- Enable custom url
 --[[
-o = s:option(Flag, "enable_custom_url", translate("Enable custom url"))
+o = s:option(Flag, "enable_custom_url", translate("Enable custom URL"))
 o.default = 0
 o.rmempty = false
 ]]--
 
 ---- gfwlist URL
-o = s:option(Value, "gfwlist_url", translate("gfwlist Update url"))
+o = s:option(Value, "gfwlist_url", translate("GFW domains(gfwlist) Update URL"))
 o:value("https://cdn.jsdelivr.net/gh/Loukky/gfwlist-by-loukky/gfwlist.txt", translate("Loukky/gfwlist-by-loukky"))
 o:value("https://cdn.jsdelivr.net/gh/gfwlist/gfwlist/gfwlist.txt", translate("gfwlist/gfwlist"))
 o.default = "https://cdn.jsdelivr.net/gh/Loukky/gfwlist-by-loukky/gfwlist.txt"
 --o:depends("enable_custom_url", 1)
 
 ----chnroute  URL
-o = s:option(Value, "chnroute_url", translate("Chnroute Update url"))
+o = s:option(Value, "chnroute_url", translate("China IPs(chnroute) Update URL"))
 o:value("https://ispip.clang.cn/all_cn.txt", translate("Clang.CN"))
 o:value("https://ispip.clang.cn/all_cn_cidr.txt", translate("Clang.CN.CIDR"))
 o.default = "https://ispip.clang.cn/all_cn.txt"

--- a/lienol/luci-app-passwall/luasrc/view/passwall/log/log.htm
+++ b/lienol/luci-app-passwall/luasrc/view/passwall/log/log.htm
@@ -11,12 +11,11 @@
 			}
 		);
 	}
-	XHR.poll(2, '<%=url([[admin]], [[services]], [[passwall]], [[get_log]])%>', null,
+	XHR.poll(30, '<%=url([[admin]], [[services]], [[passwall]], [[get_log]])%>', null,
 		function(x, data) {
 			if(x && x.status == 200) {
 				var log_textarea = document.getElementById('log_textarea');
 				log_textarea.innerHTML = x.responseText;
-				log_textarea.scrollTop = log_textarea.scrollHeight;
 			}
 		}
 	);
@@ -24,5 +23,5 @@
 </script>
 <fieldset class="cbi-section" id="_log_fieldset">
 	<input class="cbi-button cbi-input-remove" type="button" onclick="clearlog()" value="<%:Clear logs%>" />
-	<textarea id="log_textarea" class="cbi-input-textarea" style="width: 100%;margin-top: 10px;" data-update="change" rows="30" wrap="off" readonly="readonly"></textarea>
+	<textarea id="log_textarea" class="cbi-input-textarea" style="width: 100%;margin-top: 10px;" data-update="change" rows="40" wrap="off" readonly="readonly"></textarea>
 </fieldset>

--- a/lienol/luci-app-passwall/po/zh-cn/passwall.po
+++ b/lienol/luci-app-passwall/po/zh-cn/passwall.po
@@ -101,7 +101,7 @@ msgid "Clear"
 msgstr "清除"
 
 msgid "Main switch"
-msgstr "总开关"
+msgstr "主开关"
 
 msgid "TCP Node"
 msgstr "TCP节点"
@@ -124,38 +124,47 @@ msgstr "与TCP%s节点相同"
 msgid "New process"
 msgstr "另开进程"
 
-msgid "For used to surf the Internet."
-msgstr "用于科学上网。"
+msgid "For proxy specific list."
+msgstr "用于代理特定的列表。"
 
-msgid "For Game Mode or DNS resolution and more."
-msgstr "用于游戏模式或DNS解析等。"
+msgid "For proxy game network, DNS hijack etc."
+msgstr "用于代理游戏或DNS劫持等..."
 
 msgid "The selected server will not use Kcptun."
 msgstr "选中的服务器不会使用Kcptun。"
 
-msgid "The client can use the router's Socks proxy."
-msgstr "客户端可以使用路由器的Socks代理。"
+msgid "The client can use the router's Socks Servie."
+msgstr "客户端可以使用路由器的 Socks 服务。"
 
-msgid "DNS Mode"
-msgstr "DNS模式"
+msgid "Filter Mode"
+msgstr "过滤模式"
 
-msgid "Use local port 7913 as DNS"
-msgstr "使用本机7913端口的DNS"
+msgid "No Filter"
+msgstr "不过滤"
 
-msgid "No patterns are used"
-msgstr "不使用"
+msgid "IP:Port mode ecceptable for specify other filtered name services."
+msgstr "定义接受 IP:Port 形式的输入，以指定其它域名服务的过滤服务。"
 
-msgid "if has problem, please try another mode.<br />if you use no patterns are used, DNS of wan will be used by default as upstream of dnsmasq."
-msgstr "如果有问题，请尝试其他模式。<br />如果您没有使用任何模式，则会使用WAN的DNS。"
+msgid "Resolver For Local/WhiteList Domains"
+msgstr "解析本地和白名单域名"
 
-msgid "Use TCP Node Resolve DNS"
-msgstr "使用TCP节点解析DNS"
+msgid "Forced to local filter mode on 'Not China List' mode<br />IP:Port mode acceptable, multi value split with english comma."
+msgstr "在 '中国列表以外' 模式下会被强制设置为设定的DNS过滤服务<br />接受 IP:Port 形式的输入，多个以英文逗号分隔。"
 
-msgid "Use UDP Node Resolve DNS"
-msgstr "使用UDP节点解析DNS"
+msgid "Ali"
+msgstr "阿里"
 
-msgid "If checked, DNS is resolved using the TCP node."
-msgstr "如果勾选，则使用TCP节点解析DNS解决污染。"
+msgid "Baidu"
+msgstr "百度"
+
+msgid "Resolver For The List Proxied"
+msgstr "解析被代理的域名列表"
+
+msgid "Access Filtered DNS By"
+msgstr "由过滤DNS解析，经过"
+
+msgid "Forward To Socks Server"
+msgstr "转发至 Socks 服务器"
 
 msgid "Socks Server"
 msgstr "Socks服务器"
@@ -163,26 +172,20 @@ msgstr "Socks服务器"
 msgid "Misconfigured"
 msgstr "配置不当"
 
-msgid "Fair Mode"
-msgstr "公平模式"
+msgid "Make sure socks service is available on this address if 'dns2socks' selected."
+msgstr "如启用了 'dns2socks' 请确保此Socks服务可用。"
 
-msgid "DNS Address"
-msgstr "DNS地址"
+msgid "ChinaDNS-NG Fair Mode"
+msgstr "ChinaDNS-NG 公平模式"
 
-msgid "DNS Cache"
-msgstr "DNS缓存"
+msgid "Filtered DNS(For Proxied Domains)"
+msgstr "域名过滤服务(用于被代理的域名)"
 
-msgid "China DNS Server"
-msgstr "国内DNS服务器"
+msgid "Cache Resolved"
+msgstr "缓存解析结果"
 
-msgid "If you want to work with other DNS acceleration services, use the default.<br />Only use two at most, english comma separation, If you do not fill in the # and the following port, you are using port 53."
-msgstr "如果你想和其他DNS加速服务一起工作，请使用默认。<br />最多使用2个DNS服务器，英文逗号分隔，如果没有填#和后面的端口，则使用53端口。"
-
-msgid "Upstream trust DNS Server for ChinaDNS-NG"
-msgstr "ChinaDNS-NG可信DNS"
-
-msgid "You can use other resolving DNS services as trusted DNS, Example: dns2socks, dns-forwarder... 127.0.0.1#5353<br />Only use two at most, english comma separation, If you do not fill in the # and the following port, you are using port 53."
-msgstr "你可以使用其他解决污染DNS服务作为可信DNS，例：dns2socks，dns-forwarder等等。127.0.0.1#5353<br />最多使用2个DNS服务器，英文逗号分隔，如果没有填#和后面的端口，则使用53端口。"
+msgid "IP:Port mode acceptable, the 1st for 'dns2socks' if split with english comma."
+msgstr "接受 IP:Port 形式的输入，多个以英文逗号分隔 ，'dns2socks' 模式下仅首个有效。"
 
 msgid "The server client can also use this rule to scientifically surf the Internet."
 msgstr "本机服务器的客户端也可以使用这个代理模式上网。"
@@ -196,15 +199,6 @@ msgstr "可以使用负载均衡实现故障切换功能。"
 msgid "Restore the default configuration method. Input example in the address bar:"
 msgstr "恢复默认配置方法，地址栏输入例："
 
-msgid "dnsbyisp"
-msgstr "运营商DNS(自动分配)"
-
-msgid "Ali"
-msgstr "阿里"
-
-msgid "Baidu"
-msgstr "百度"
-
 msgid "DNS Export Of Multi WAN"
 msgstr "国内DNS指定解析出口"
 
@@ -217,17 +211,8 @@ msgstr "只有多线接入才有效。"
 msgid "Not Specify"
 msgstr "不指定"
 
-msgid "DNS Hijack"
-msgstr "DNS劫持"
-
 msgid "custom"
 msgstr "自定义"
-
-msgid "DNS Server"
-msgstr "DNS服务器"
-
-msgid "Use Socks Node Resolve DNS"
-msgstr "使用Socks节点解析DNS"
 
 msgid "Multi Process Option"
 msgstr "多进程并发"
@@ -254,16 +239,16 @@ msgid "Global Proxy"
 msgstr "全局代理"
 
 msgid "GFW List"
-msgstr "GFW名单"
+msgstr "防火墙表"
 
-msgid "China WhiteList"
-msgstr "大陆白名单"
+msgid "Not China List"
+msgstr "中国列表以外"
 
 msgid "Game Mode"
 msgstr "游戏模式"
 
-msgid "Return Home"
-msgstr "回国模式"
+msgid "China List"
+msgstr "中国列表"
 
 msgid "Localhost"
 msgstr "本机"
@@ -616,14 +601,14 @@ msgstr "备用"
 msgid "Manually update"
 msgstr "手动更新"
 
-msgid "Enable custom url"
+msgid "Enable custom URL"
 msgstr "启用自定义规则地址"
 
-msgid "gfwlist Update url"
-msgstr "GFWList更新URL"
+msgid "GFW domains(gfwlist) Update URL"
+msgstr "防火墙域名列表(gfwlist)更新URL"
 
-msgid "Chnroute Update url"
-msgstr "国内IP段(Chnroute)更新URL"
+msgid "China IPs(chnroute) Update URL"
+msgstr "中国IP段(chnroute)更新URL"
 
 msgid "Rule status"
 msgstr "规则版本"

--- a/lienol/luci-app-passwall/root/usr/share/passwall/iptables.sh
+++ b/lienol/luci-app-passwall/root/usr/share/passwall/iptables.sh
@@ -82,13 +82,13 @@ get_action_chain_name() {
 		echo "全局代理"
 		;;
 	gfwlist)
-		echo "GFW名单"
+		echo "防火墙列表"
 		;;
 	chnroute)
-		echo "大陆白名单"
+		echo "中国列表以外"
 		;;
 	returnhome)
-		echo "回国模式"
+		echo "中国列表"
 		;;
 	esac
 }


### PR DESCRIPTION
* recommend chnroute mode for users behind the GFW
- remove the confusing 'dnsbyisp' option

Signed-off-by: peter-tank <30540412+peter-tank@users.noreply.github.com>