### PR TITLE
final PR here, quit maintaining.

### DIFF
--- a/lienol/luci-app-passwall/luasrc/model/cbi/passwall/acl.lua
+++ b/lienol/luci-app-passwall/luasrc/model/cbi/passwall/acl.lua
@@ -114,8 +114,8 @@ o:value("default", translate("Default"))
 o:value("disable", translate("No Proxy"))
 o:value("global", translate("Global Proxy"))
 o:value("gfwlist", translate("GFW List"))
-o:value("chnroute", translate("China WhiteList"))
-o:value("returnhome", translate("Return Home"))
+o:value("chnroute", translate("Not China List"))
+o:value("returnhome", translate("China List"))
 
 ---- UDP Proxy Mode
 o = s:option(ListValue, "udp_proxy_mode", "UDP" .. translate("Proxy Mode"))
@@ -125,8 +125,8 @@ o:value("default", translate("Default"))
 o:value("disable", translate("No Proxy"))
 o:value("global", translate("Global Proxy"))
 o:value("gfwlist", translate("GFW List"))
-o:value("chnroute", translate("Game Mode") .. "（" .. translate("China WhiteList") .. "）")
-o:value("returnhome", translate("Return Home"))
+o:value("chnroute", translate("Game Mode") .. "（" .. translate("Not China List") .. "）")
+o:value("returnhome", translate("China List"))
 
 ---- TCP No Redir Ports
 o = s:option(Value, "tcp_no_redir_ports", translate("TCP No Redir Ports"))

--- a/lienol/luci-app-passwall/luasrc/model/cbi/passwall/global.lua
+++ b/lienol/luci-app-passwall/luasrc/model/cbi/passwall/global.lua
@@ -57,14 +57,13 @@ else
     m:append(Template(appname .. "/global/status2"))
 end
 
--- [[ Global Settings ]]--
-s = m:section(TypedSection, "global")
+s = m:section(TypedSection, "global", translate("Main Settings"))
 s.anonymous = true
 s.addremove = false
 
-s:tab("Main", translate("Main Settings"))
+s:tab("Main", translate("Main"))
 
----- Main switch
+-- [[ Global Settings ]]--
 o = s:taboption("Main", Flag, "enabled", translate("Main switch"))
 o.rmempty = false
 
@@ -73,7 +72,7 @@ local tcp_node_num = tonumber(m:get("@global_other[0]", "tcp_node_num") or 1)
 for i = 1, tcp_node_num, 1 do
     if i == 1 then
         o = s:taboption("Main", ListValue, "tcp_node" .. i, translate("TCP Node"))
-        -- o.description = translate("For used to surf the Internet.")
+        o.description = translate("For proxy specific list.")
     else
         o = s:taboption("Main", ListValue, "tcp_node" .. i,
                      translate("TCP Node") .. " " .. i)
@@ -87,7 +86,7 @@ local udp_node_num = tonumber(m:get("@global_other[0]", "udp_node_num") or 1)
 for i = 1, udp_node_num, 1 do
     if i == 1 then
         o = s:taboption("Main", ListValue, "udp_node" .. i, translate("UDP Node"))
-        -- o.description = translate("For Game Mode or DNS resolution and more.") .. translate("The selected server will not use Kcptun.")
+        o.description = translate("For proxy game network, DNS hijack etc.") .. translate(" The selected server will not use Kcptun.")
         o:value("nil", translate("Close"))
         o:value("tcp", translate("Same as the tcp node"))
         o:value("tcp_", translate("Same as the tcp node") .. "（" .. translate("New process") .. "）")
@@ -99,26 +98,10 @@ for i = 1, udp_node_num, 1 do
     for k, v in pairs(nodes_table) do o:value(v.id, v.remarks) end
 end
 
-s:tab("DNS", translate("DNS Settings"))
-
-o = s:taboption("DNS", Value, "up_china_dns", translate("China DNS Server") .. "(UDP)")
--- o.description = translate("If you want to work with other DNS acceleration services, use the default.<br />Only use two at most, english comma separation, If you do not fill in the # and the following port, you are using port 53.")
-o.default = "default"
-o:value("default", translate("Default"))
-o:value("dnsbyisp", translate("dnsbyisp"))
-o:value("223.5.5.5", "223.5.5.5 (" .. translate("Ali") .. "DNS)")
-o:value("223.6.6.6", "223.6.6.6 (" .. translate("Ali") .. "DNS)")
-o:value("114.114.114.114", "114.114.114.114 (114DNS)")
-o:value("114.114.115.115", "114.114.115.115 (114DNS)")
-o:value("119.29.29.29", "119.29.29.29 (DNSPOD DNS)")
-o:value("182.254.116.116", "182.254.116.116 (DNSPOD DNS)")
-o:value("1.2.4.8", "1.2.4.8 (CNNIC DNS)")
-o:value("210.2.4.8", "210.2.4.8 (CNNIC DNS)")
-o:value("180.76.76.76", "180.76.76.76 (" .. translate("Baidu") .. "DNS)")
+s:tab("DNS", translate("DNS"))
 
 ---- DNS Forward Mode
-o = s:taboption("DNS", Value, "dns_mode", translate("DNS Mode"))
--- o.description = translate("if has problem, please try another mode.<br />if you use no patterns are used, DNS of wan will be used by default as upstream of dnsmasq.")
+o = s:taboption("DNS", Value, "dns_mode", translate("Filter Mode"))
 o.rmempty = false
 o:reset_values()
 if api.is_finded("chinadns-ng") then
@@ -130,55 +113,60 @@ end
 if api.is_finded("dns2socks") then
     o:value("dns2socks", "dns2socks")
 end
-o:value("nonuse", translate("No patterns are used"))
+o:value("nonuse", translate("No Filter"))
+
+o = s:taboption("DNS", Value, "up_china_dns", translate("Resolver For Local/WhiteList Domains") .. "(UDP)")
+o.description = translate("Forced to local filter mode on 'Not China List' mode<br />IP:Port mode acceptable, multi value split with english comma.")
+o.default = "default"
+o:value("default", translate("Default"))
+o:value("223.5.5.5", "223.5.5.5 (" .. translate("Ali") .. "DNS)")
+o:value("223.6.6.6", "223.6.6.6 (" .. translate("Ali") .. "DNS)")
+o:value("114.114.114.114", "114.114.114.114 (114DNS)")
+o:value("114.114.115.115", "114.114.115.115 (114DNS)")
+o:value("119.29.29.29", "119.29.29.29 (DNSPOD DNS)")
+o:value("182.254.116.116", "182.254.116.116 (DNSPOD DNS)")
+o:value("1.2.4.8", "1.2.4.8 (CNNIC DNS)")
+o:value("210.2.4.8", "210.2.4.8 (CNNIC DNS)")
+o:value("180.76.76.76", "180.76.76.76 (" .. translate("Baidu") .. "DNS)")
 
 o = s:taboption("DNS", ListValue, "up_trust_pdnsd_dns",
-             translate("Upstream trust DNS Server for Pdnsd"))
+             translate("Resolver For The List Proxied"))
 -- o.description = translate("You can use other resolving DNS services as trusted DNS, Example: dns2socks, dns-forwarder... 127.0.0.1#5353<br />Only use two at most, english comma separation, If you do not fill in the # and the following port, you are using port 53.")
 o.default = ""
-o:value("", "pdnsd + " .. translate("Use TCP Node Resolve DNS"))
-o:value("udp", translate("Use UDP Node Resolve DNS"))
+if api.is_finded("pdnsd") then
+    o:value("", "pdnsd + " .. translate("Access Filtered DNS By ") .. translate("TCP Node"))
+end
+o:value("udp", translate("Access Filtered DNS By ") .. translate("UDP Node"))
 if api.is_finded("dns2socks") then
     o:value("dns2socks", "dns2socks")
 end
 o:depends("dns_mode", "pdnsd")
 
----- Upstream trust DNS Server for ChinaDNS-NG
-o = s:taboption("DNS", ListValue, "up_trust_chinadns_ng_dns",
-             translate("Upstream trust DNS Server for ChinaDNS-NG") .. "(UDP)")
--- o.description = translate("You can use other resolving DNS services as trusted DNS, Example: dns2socks, dns-forwarder... 127.0.0.1#5353<br />Only use two at most, english comma separation, If you do not fill in the # and the following port, you are using port 53.")
+o = s:taboption("DNS", ListValue, "up_trust_chinadns_ng_dns", translate("Resolver For The List Proxied") .. "(UDP)")
 o.default = "pdnsd"
 if api.is_finded("pdnsd") then
-    o:value("pdnsd", "pdnsd + " .. translate("Use TCP Node Resolve DNS"))
+    o:value("pdnsd", "pdnsd, " .. translate("Access Filtered DNS By ") .. translate("TCP Node"))
 end
+o:value("udp", translate("Access Filtered DNS By ") .. translate("UDP Node"))
 if api.is_finded("dns2socks") then
     o:value("dns2socks", "dns2socks")
 end
-o:value("udp", translate("Use UDP Node Resolve DNS"))
 o:depends("dns_mode", "chinadns-ng")
 
----- Use TCP Node Resolve DNS
---[[ if api.is_finded("pdnsd") then
-    o = s:taboption("DNS", Flag, "use_tcp_node_resolve_dns", translate("Use TCP Node Resolve DNS"))
-    o.description = translate("If checked, DNS is resolved using the TCP node.")
-    o.default = 1
-    o:depends("dns_mode", "pdnsd")
-end
---]]
-
-o = s:taboption("DNS", Value, "socks_server", translate("Socks Server"))
+---- Upstream trust DNS Mode for ChinaDNS-NG
+o = s:taboption("DNS", Value, "socks_server", translate("Socks Server"), translate("Make sure socks service is available on this address if 'dns2socks' selected."))
 o.default = ""
+for k, v in pairs(socks_table) do o:value(v.id, v.remarks) end
 o:depends({dns_mode = "dns2socks"})
 o:depends({dns_mode = "chinadns-ng", up_trust_chinadns_ng_dns = "dns2socks"})
 o:depends({dns_mode = "pdnsd", up_trust_pdnsd_dns = "dns2socks"})
-for k, v in pairs(socks_table) do o:value(v.id, v.remarks) end
 
-o = s:taboption("DNS", Flag, "fair_mode", translate("Fair Mode"))
+o = s:taboption("DNS", Flag, "fair_mode", translate("ChinaDNS-NG Fair Mode"))
 o.default = "1"
 o:depends({dns_mode = "chinadns-ng"})
 
 ---- DNS Forward
-o = s:taboption("DNS", Value, "dns_forward", translate("DNS Address"))
+o = s:taboption("DNS", Value, "dns_forward", translate("Filtered DNS(For Proxied Domains)"), translate("IP:Port mode acceptable, the 1st for 'dns2socks' if split with english comma."))
 o.default = "8.8.4.4"
 o:value("8.8.4.4", "8.8.4.4 (Google DNS)")
 o:value("8.8.8.8", "8.8.8.8 (Google DNS)")
@@ -188,17 +176,17 @@ o:depends({dns_mode = "chinadns-ng"})
 o:depends({dns_mode = "dns2socks"})
 o:depends({dns_mode = "pdnsd"})
 
-o = s:taboption("DNS", Flag, "dns_cache", translate("DNS Cache"))
+o = s:taboption("DNS", Flag, "dns_cache", translate("Cache Resolved"))
 o.default = "1"
 o:depends({dns_mode = "chinadns-ng", up_trust_chinadns_ng_dns = "pdnsd"})
 o:depends({dns_mode = "chinadns-ng", up_trust_chinadns_ng_dns = "dns2socks"})
 o:depends({dns_mode = "dns2socks"})
 o:depends({dns_mode = "pdnsd"})
 
-s:tab("Mode", translate("Proxy Mode"))
+s:tab("Proxy", translate("Mode"))
 
 ---- TCP Default Proxy Mode
-o = s:taboption("Mode", ListValue, "tcp_proxy_mode",
+o = s:taboption("Proxy", ListValue, "tcp_proxy_mode",
              "TCP" .. translate("Default") .. translate("Proxy Mode"))
 -- o.description = translate("If not available, try clearing the cache.")
 o.default = "chnroute"
@@ -206,38 +194,38 @@ o.rmempty = false
 o:value("disable", translate("No Proxy"))
 o:value("global", translate("Global Proxy"))
 o:value("gfwlist", translate("GFW List"))
-o:value("chnroute", translate("China WhiteList"))
-o:value("returnhome", translate("Return Home"))
+o:value("chnroute", translate("Not China List"))
+o:value("returnhome", translate("China List"))
 
 ---- UDP Default Proxy Mode
-o = s:taboption("Mode", ListValue, "udp_proxy_mode",
+o = s:taboption("Proxy", ListValue, "udp_proxy_mode",
              "UDP" .. translate("Default") .. translate("Proxy Mode"))
 o.default = "chnroute"
 o.rmempty = false
 o:value("disable", translate("No Proxy"))
 o:value("global", translate("Global Proxy"))
 o:value("gfwlist", translate("GFW List"))
-o:value("chnroute", translate("Game Mode") .. "（" .. translate("China WhiteList") .. "）")
-o:value("returnhome", translate("Return Home"))
+o:value("chnroute", translate("Game Mode") .. "（" .. translate("Not China List") .. "）")
+o:value("returnhome", translate("China List"))
 
 ---- Localhost TCP Proxy Mode
-o = s:taboption("Mode", ListValue, "localhost_tcp_proxy_mode",
+o = s:taboption("Proxy", ListValue, "localhost_tcp_proxy_mode",
              translate("Router Localhost") .. "TCP" .. translate("Proxy Mode"))
 -- o.description = translate("The server client can also use this rule to scientifically surf the Internet.")
 o:value("default", translate("Default"))
 o:value("gfwlist", translate("GFW List"))
-o:value("chnroute", translate("China WhiteList"))
+o:value("chnroute", translate("Not China List"))
 o:value("global", translate("Global Proxy"))
 o.default = "default"
 o.rmempty = false
 
 ---- Localhost UDP Proxy Mode
-o = s:taboption("Mode", ListValue, "localhost_udp_proxy_mode",
+o = s:taboption("Proxy", ListValue, "localhost_udp_proxy_mode",
              translate("Router Localhost") .. "UDP" .. translate("Proxy Mode"))
 o:value("disable", translate("No Proxy"))
 o:value("default", translate("Default"))
 o:value("gfwlist", translate("GFW List"))
-o:value("chnroute", translate("Game Mode") .. "（" .. translate("China WhiteList") .. "）")
+o:value("chnroute", translate("Game Mode") .. "（" .. translate("Not China List") .. "）")
 o:value("global", translate("Global Proxy"))
 o.default = "default"
 o.rmempty = false

--- a/lienol/luci-app-passwall/luasrc/model/cbi/passwall/rule.lua
+++ b/lienol/luci-app-passwall/luasrc/model/cbi/passwall/rule.lua
@@ -14,20 +14,20 @@ o.rmempty = false
 
 ---- Enable custom url
 --[[
-o = s:option(Flag, "enable_custom_url", translate("Enable custom url"))
+o = s:option(Flag, "enable_custom_url", translate("Enable custom URL"))
 o.default = 0
 o.rmempty = false
 ]]--
 
 ---- gfwlist URL
-o = s:option(Value, "gfwlist_url", translate("gfwlist Update url"))
+o = s:option(Value, "gfwlist_url", translate("GFW domains(gfwlist) Update URL"))
 o:value("https://cdn.jsdelivr.net/gh/Loukky/gfwlist-by-loukky/gfwlist.txt", translate("Loukky/gfwlist-by-loukky"))
 o:value("https://cdn.jsdelivr.net/gh/gfwlist/gfwlist/gfwlist.txt", translate("gfwlist/gfwlist"))
 o.default = "https://cdn.jsdelivr.net/gh/Loukky/gfwlist-by-loukky/gfwlist.txt"
 --o:depends("enable_custom_url", 1)
 
 ----chnroute  URL
-o = s:option(Value, "chnroute_url", translate("Chnroute Update url"))
+o = s:option(Value, "chnroute_url", translate("China IPs(chnroute) Update URL"))
 o:value("https://ispip.clang.cn/all_cn.txt", translate("Clang.CN"))
 o:value("https://ispip.clang.cn/all_cn_cidr.txt", translate("Clang.CN.CIDR"))
 o.default = "https://ispip.clang.cn/all_cn.txt"

--- a/lienol/luci-app-passwall/luasrc/view/passwall/log/log.htm
+++ b/lienol/luci-app-passwall/luasrc/view/passwall/log/log.htm
@@ -11,7 +11,7 @@
 			}
 		);
 	}
-	XHR.poll(2, '<%=url([[admin]], [[services]], [[passwall]], [[get_log]])%>', null,
+	XHR.poll(30, '<%=url([[admin]], [[services]], [[passwall]], [[get_log]])%>', null,
 		function(x, data) {
 			if(x && x.status == 200) {
 				var log_textarea = document.getElementById('log_textarea');

--- a/lienol/luci-app-passwall/po/zh-cn/passwall.po
+++ b/lienol/luci-app-passwall/po/zh-cn/passwall.po
@@ -1,5 +1,5 @@
 msgid "Pass Wall"
-msgstr "PassWall"
+msgstr "爬墙(PassWall)"
 
 msgid "Auto"
 msgstr "自动"
@@ -101,7 +101,7 @@ msgid "Clear"
 msgstr "清除"
 
 msgid "Main switch"
-msgstr "总开关"
+msgstr "主开关"
 
 msgid "TCP Node"
 msgstr "TCP节点"
@@ -124,38 +124,47 @@ msgstr "与TCP%s节点相同"
 msgid "New process"
 msgstr "另开进程"
 
-msgid "For used to surf the Internet."
-msgstr "用于科学上网。"
+msgid "For proxy specific list."
+msgstr "用于代理特定的列表。"
 
-msgid "For Game Mode or DNS resolution and more."
-msgstr "用于游戏模式或DNS解析等。"
+msgid "For proxy game network, DNS hijack etc."
+msgstr "用于代理游戏或DNS劫持等..."
 
 msgid "The selected server will not use Kcptun."
 msgstr "选中的服务器不会使用Kcptun。"
 
-msgid "The client can use the router's Socks proxy."
-msgstr "客户端可以使用路由器的Socks代理。"
+msgid "The client can use the router's Socks Servie."
+msgstr "客户端可以使用路由器的 Socks 服务。"
 
-msgid "DNS Mode"
-msgstr "DNS模式"
+msgid "Filter Mode"
+msgstr "过滤模式"
 
-msgid "Use local port 7913 as DNS"
-msgstr "使用本机7913端口的DNS"
+msgid "No Filter"
+msgstr "不过滤"
 
-msgid "No patterns are used"
-msgstr "不使用"
+msgid "IP:Port mode ecceptable for specify other filtered name services."
+msgstr "定义接受 IP:Port 形式的输入，以指定其它域名服务的过滤服务。"
 
-msgid "if has problem, please try another mode.<br />if you use no patterns are used, DNS of wan will be used by default as upstream of dnsmasq."
-msgstr "如果有问题，请尝试其他模式。<br />如果您没有使用任何模式，则会使用WAN的DNS。"
+msgid "Resolver For Local/WhiteList Domains"
+msgstr "解析本地和白名单域名"
 
-msgid "Use TCP Node Resolve DNS"
-msgstr "使用TCP节点解析DNS"
+msgid "Forced to local filter mode on 'Not China List' mode<br />IP:Port mode acceptable, multi value split with english comma."
+msgstr "在 '中国列表以外' 模式下会被强制设置为设定的DNS过滤服务<br />接受 IP:Port 形式的输入，多个以英文逗号分隔。"
 
-msgid "Use UDP Node Resolve DNS"
-msgstr "使用UDP节点解析DNS"
+msgid "Ali"
+msgstr "阿里"
 
-msgid "If checked, DNS is resolved using the TCP node."
-msgstr "如果勾选，则使用TCP节点解析DNS解决污染。"
+msgid "Baidu"
+msgstr "百度"
+
+msgid "Resolver For The List Proxied"
+msgstr "解析被代理的域名列表"
+
+msgid "Access Filtered DNS By"
+msgstr "由过滤DNS解析，经过"
+
+msgid "Forward To Socks Server"
+msgstr "转发至 Socks 服务器"
 
 msgid "Socks Server"
 msgstr "Socks服务器"
@@ -163,29 +172,20 @@ msgstr "Socks服务器"
 msgid "Misconfigured"
 msgstr "配置不当"
 
-msgid "Fair Mode"
-msgstr "公平模式"
+msgid "Make sure socks service is available on this address if 'dns2socks' selected."
+msgstr "如启用了 'dns2socks' 请确保此Socks服务可用。"
 
-msgid "DNS Address"
-msgstr "DNS地址"
+msgid "ChinaDNS-NG Fair Mode"
+msgstr "ChinaDNS-NG 公平模式"
 
-msgid "DNS Cache"
-msgstr "DNS缓存"
+msgid "Filtered DNS(For Proxied Domains)"
+msgstr "域名过滤服务(用于被代理的域名)"
 
-msgid "China DNS Server"
-msgstr "国内DNS服务器"
+msgid "Cache Resolved"
+msgstr "缓存解析结果"
 
-msgid "If you want to work with other DNS acceleration services, use the default.<br />Only use two at most, english comma separation, If you do not fill in the # and the following port, you are using port 53."
-msgstr "如果你想和其他DNS加速服务一起工作，请使用默认。<br />最多使用2个DNS服务器，英文逗号分隔，如果没有填#和后面的端口，则使用53端口。"
-
-msgid "Upstream trust DNS Server for Pdnsd"
-msgstr "Pdnsd可信DNS"
-
-msgid "Upstream trust DNS Server for ChinaDNS-NG"
-msgstr "ChinaDNS-NG可信DNS"
-
-msgid "You can use other resolving DNS services as trusted DNS, Example: dns2socks, dns-forwarder... 127.0.0.1#5353<br />Only use two at most, english comma separation, If you do not fill in the # and the following port, you are using port 53."
-msgstr "你可以使用其他解决污染DNS服务作为可信DNS，例：dns2socks，dns-forwarder等等。127.0.0.1#5353<br />最多使用2个DNS服务器，英文逗号分隔，如果没有填#和后面的端口，则使用53端口。"
+msgid "IP:Port mode acceptable, the 1st for 'dns2socks' if split with english comma."
+msgstr "接受 IP:Port 形式的输入，多个以英文逗号分隔 ，'dns2socks' 模式下仅首个有效。"
 
 msgid "The server client can also use this rule to scientifically surf the Internet."
 msgstr "本机服务器的客户端也可以使用这个代理模式上网。"
@@ -199,15 +199,6 @@ msgstr "可以使用负载均衡实现故障切换功能。"
 msgid "Restore the default configuration method. Input example in the address bar:"
 msgstr "恢复默认配置方法，地址栏输入例："
 
-msgid "dnsbyisp"
-msgstr "运营商DNS(自动分配)"
-
-msgid "Ali"
-msgstr "阿里"
-
-msgid "Baidu"
-msgstr "百度"
-
 msgid "DNS Export Of Multi WAN"
 msgstr "国内DNS指定解析出口"
 
@@ -220,17 +211,8 @@ msgstr "只有多线接入才有效。"
 msgid "Not Specify"
 msgstr "不指定"
 
-msgid "DNS Hijack"
-msgstr "DNS劫持"
-
 msgid "custom"
 msgstr "自定义"
-
-msgid "DNS Server"
-msgstr "DNS服务器"
-
-msgid "Use Socks Node Resolve DNS"
-msgstr "使用Socks节点解析DNS"
 
 msgid "Multi Process Option"
 msgstr "多进程并发"
@@ -257,16 +239,16 @@ msgid "Global Proxy"
 msgstr "全局代理"
 
 msgid "GFW List"
-msgstr "GFW名单"
+msgstr "防火墙表"
 
-msgid "China WhiteList"
-msgstr "大陆白名单"
+msgid "Not China List"
+msgstr "中国列表以外"
 
 msgid "Game Mode"
 msgstr "游戏模式"
 
-msgid "Return Home"
-msgstr "回国模式"
+msgid "China List"
+msgstr "中国列表"
 
 msgid "Localhost"
 msgstr "本机"
@@ -619,14 +601,14 @@ msgstr "备用"
 msgid "Manually update"
 msgstr "手动更新"
 
-msgid "Enable custom url"
+msgid "Enable custom URL"
 msgstr "启用自定义规则地址"
 
-msgid "gfwlist Update url"
-msgstr "GFWList更新URL"
+msgid "GFW domains(gfwlist) Update URL"
+msgstr "防火墙域名列表(gfwlist)更新URL"
 
-msgid "Chnroute Update url"
-msgstr "国内IP段(Chnroute)更新URL"
+msgid "China IPs(chnroute) Update URL"
+msgstr "中国IP段(chnroute)更新URL"
 
 msgid "Rule status"
 msgstr "规则版本"

--- a/lienol/luci-app-passwall/root/usr/share/passwall/app.sh
+++ b/lienol/luci-app-passwall/root/usr/share/passwall/app.sh
@@ -292,8 +292,8 @@ load_config() {
 	LOCAL_DNS=$(config_t_get global up_china_dns dnsbyisp | sed 's/:/#/g')
 	[ -f "${RESOLVFILE}" ] && [ -s "${RESOLVFILE}" ] || RESOLVFILE=/tmp/resolv.conf.auto
 	DEFAULT_DNS=$(sed -n 's/^nameserver[ \t]*\([^ ]*\)$/\1/p' "${RESOLVFILE}" | grep -v "0.0.0.0" | grep -v "127.0.0.1" | grep -v "^::$" | tr '\n' ',')
-	if [ "${LOCAL_DNS}" = "default" ] || [ "${LOCAL_DNS}" = "dnsbyisp" ]; then
-		[ "${LOCAL_DNS}" = "default" ] && IS_DEFAULT_DNS=1
+	if [ "${LOCAL_DNS}" = "default" ]; then
+		IS_DEFAULT_DNS=1
 		LOCAL_DNS="${DEFAULT_DNS:-119.29.29.29}"
 	fi
 	PROXY_IPV6=$(config_t_get global_forwarding proxy_ipv6 0)
@@ -660,9 +660,10 @@ start_dns() {
 			msg="pdnsd"
 			echolog "  | - (chinadns-ng) 只支持2~4级的域名过滤，列表外的域名查询会同时发送给本地DNS(可切换到Pdnsd + TCP节点模式解决)..."
 			echolog "  | - (chinadns-ng) 虽然列表外域名查询的结果，不在中国IP段内(chnroute/chnroute6)时，只采信上游代理 DNS 的应答..."
-			echolog "  | - (chinadns-ng) 上游代理 DNS 有一定概率会比国内 DNS 先返回的话(比如上游代理 DNS 的本地查询缓存)，启用 '公平模式' 可以优先接受本地 DNS 的中国IP段内(chnroute/chnroute6)的应答..."
+			echolog "  | - (chinadns-ng) 上游代理 DNS 有一定概率会比本地 DNS 先返回的话(比如上游代理 DNS 的本地查询缓存)，启用 '公平模式' 可以优先接受本地 DNS 的中国IP段内(chnroute/chnroute6)的应答..."
 		elif [ "$up_trust_chinadns_ng_dns" = "dns2socks" ]; then
 			dns2socks_listen=${china_ng_gfw}
+			TUN_DNS="${dns2socks_listen}"
 			msg="dns2socks"
 		elif [ "$up_trust_chinadns_ng_dns" = "udp" ]; then
 			use_udp_node_resolve_dns=1
@@ -704,39 +705,62 @@ start_dns() {
 		echolog "  - dns2sock(${dns2socks_listen}${dns2sock_cache})，${dns2socks_socks_server:-127.0.0.1:9050} -> ${dns2socks_forward-D46.182.19.48:53}"
 	fi
 	[ "${use_udp_node_resolve_dns}" = "1" ] && echolog "  * 要求代理 DNS 请求，如上游 DNS 非直连地址，确保 UDP 代理打开，并且已经正确转发"
-	[ "${use_tcp_node_resolve_dns}" = "1" ] && echolog "  * 请确认上游 DNS 支持TCP查询，如非直连地址，确保 TCP 代理打开，并且已经正确转发"
+	[ "${use_tcp_node_resolve_dns}" = "1" ] && echolog "  * 请确认上游 DNS 支持 TCP 查询，如非直连地址，确保 TCP 代理打开，并且已经正确转发"
 }
 
 add_dnsmasq() {
-	local adblock returnhome fwd_dns items item servers
+	local global returnhome chnlist gfwlist force_local filtered_dns fwd_dns items item servers msg
 
-	adblock=$(config_t_get global_rules adblock 0)
-	mkdir -p "$TMP_DNSMASQ_PATH" "$DNSMASQ_PATH" /var/dnsmasq.d
-
-	[ "${adblock}" = "1" ] && {
-		[ -f "${RULES_PATH}/adblock.conf" ] && ln -s "${RULES_PATH}/adblock.conf" "${TMP_DNSMASQ_PATH}/adblock.conf"
+	mkdir -p "${TMP_DNSMASQ_PATH}" "${DNSMASQ_PATH}" "/var/dnsmasq.d"
+	[ "$(config_t_get global_rules adblock 0)" = "1" ] && {
+		ln -s "${RULES_PATH}/adblock.conf" "${TMP_DNSMASQ_PATH}/adblock.conf"
+		echolog "  - [$?]广告域名表中域名解析请求直接应答为 '0.0.0.0'"
 	}
-	
-	[ "$DNS_MODE" != "nonuse" ] && {
+
+	if [ "${DNS_MODE}" = "nonuse" ]; then
+		echolog "  - 不对域名进行分流解析"
+	else
+		global=$(echo "${TCP_PROXY_MODE}${LOCALHOST_TCP_PROXY_MODE}${UDP_PROXY_MODE}${LOCALHOST_UDP_PROXY_MODE}" | grep "global")
 		returnhome=$(echo "${TCP_PROXY_MODE}${LOCALHOST_TCP_PROXY_MODE}${UDP_PROXY_MODE}${LOCALHOST_UDP_PROXY_MODE}" | grep "returnhome")
-		[ "${IS_DEFAULT_DNS}" = "1" ] || fwd_dns="${LOCAL_DNS}"
-		[ "$DNS_MODE" = "chinadns-ng" ] && unset fwd_dns
-		sort -u "${RULES_PATH}/direct_host" | gen_dnsmasq_items "whitelist" "${fwd_dns}" "${TMP_DNSMASQ_PATH}/direct_host.conf"
-		echolog "  - [$?]域名白名单(whitelist)：${fwd_dns:-默认}"
+		chnlist=$(echo "${TCP_PROXY_MODE}${LOCALHOST_TCP_PROXY_MODE}${UDP_PROXY_MODE}${LOCALHOST_UDP_PROXY_MODE}" | grep "chnroute")
+		gfwlist=$(echo "${TCP_PROXY_MODE}${LOCALHOST_TCP_PROXY_MODE}${UDP_PROXY_MODE}${LOCALHOST_UDP_PROXY_MODE}" | grep "gfwlist")
+		if [ "${IS_DEFAULT_DNS}" = "1" ]; then
+			force_local=1
+			[ -n "${chnlist}" ] && force_local=2
+			[ "${DNS_MODE}" = "other_dns" ] || [ "${DNS_MODE}" = "chinadns-ng" ] && force_local=3
+		fi
+		[ "${DNS_MODE}" = "other_dns" ] || [ "${DNS_MODE}" = "chinadns-ng" ] || [ -n "${global}${chnlist}" ] && filtered_dns=1
 
 		fwd_dns="${LOCAL_DNS}"
+		[ -z "${global}" ] && {
+			[ -z "${chnlist}" ] || [ -n "${returnhome}" ] && [ -n "${force_local}" ] && [ "${filtered_dns}" != "1" ] && unset fwd_dns
+			sort -u "${RULES_PATH}/direct_host" | gen_dnsmasq_items "whitelist" "${fwd_dns}" "${TMP_DNSMASQ_PATH}/direct_host.conf"
+			echolog "  - [$?]域名白名单(whitelist)：${fwd_dns:-默认}"
+		}
+
+		servers=$(uci show "${CONFIG}" | grep ".address=" | cut -d "'" -f 2)
+		[ "${filtered_dns}" = "1" ] && [ "${DNS_MODE}" != "chinadns-ng" ] && [ -z "${global}${chnlist}" ] && unset fwd_dns
 		hosts_foreach "servers" host_from_url | grep -v "google.c" | grep '[a-zA-Z]$' | sort -u | gen_dnsmasq_items "vpsiplist" "${fwd_dns}" "${TMP_DNSMASQ_PATH}/vpsiplist_host.conf"
 		echolog "  - [$?]节点列表中的域名(vpsiplist)：${fwd_dns:-默认}"
 
-		fwd_dns="${TUN_DNS}"
-		[ "${DNS_MODE}" = "chinadns-ng" ] && [ -z "${returnhome}" ] && unset fwd_dns
-		sort -u "${RULES_PATH}/proxy_host" | gen_dnsmasq_items "blacklist" "${fwd_dns}" "${TMP_DNSMASQ_PATH}/proxy_host.conf"
-		echolog "  - [$?]代理域名表(blacklist)：${fwd_dns:-默认}"
+		[ -n "${returnhome}" ] || [ "${filtered_dns}" = "1" ] && {
+			[ -n "${gfwlist}" ] && fwd_dns="${LOCAL_DNS}"
+			[ "${filtered_dns}" = "1" ] && [ -z "${chnlist}" ] && unset fwd_dns
+			[ "${DNS_MODE}" = "chinadns-ng" ] && fwd_dns="127.0.0.1#${DNS_PORT}"
+			[ -n "${returnhome}" ] && fwd_dns="${TUN_DNS}"
+			[ -n "${global}" ] && unset fwd_dns
+			sort -u "${RULES_PATH}/chnlist" | gen_dnsmasq_items "chnroute" "${fwd_dns}" "${TMP_DNSMASQ_PATH}/chinalist_host.conf"
+			echolog "  - [$?]中国域名表(chnroute)：${fwd_dns:-默认}"
+		}
 
 		fwd_dns="${TUN_DNS}"
-		# don't mess up usage of proxy china list mode
-		[ -z "${returnhome}" ] && {
-			[ "${DNS_MODE}" = "chinadns-ng" ] || [ "${IS_DEFAULT_DNS}" = "1" ] && unset fwd_dns
+		[ "${filtered_dns}" = "1" ] && [ -z "${returnhome}" ] && unset fwd_dns
+		[ -n "${global}" ] && unset fwd_dns
+		sort -u "${RULES_PATH}/proxy_host" | sed 's/^\.\(.*\)$/\1/g' | gen_dnsmasq_items "blacklist" "${fwd_dns}" "${TMP_DNSMASQ_PATH}/proxy_host.conf"
+		echolog "  - [$?]代理域名表(blacklist)：${fwd_dns:-默认}"
+
+		[ -n "${gfwlist}" ] || [ "${filtered_dns}" = "1" ] && [ -z "${returnhome}" ] && {
+			[ "${filtered_dns}" = "1" ] && [ "${DNS_MODE}" != "chinadns-ng" ] && unset fwd_dns
 			sort -u "${TMP_PATH}/gfwlist.txt" | gen_dnsmasq_items "gfwlist" "${fwd_dns}" "${TMP_DNSMASQ_PATH}/gfwlist.conf"
 			echolog "  - [$?]防火墙域名表(gfwlist)：${fwd_dns:-默认}"
 		}
@@ -748,20 +772,37 @@ add_dnsmasq() {
 				echolog "  - [$?]节点订阅用域名，$(host_from_url $(config_n_get ${item} url))：${fwd_dns:-默认}"
 			done
 		}
-	}
+	fi
 	
-	if [ "${IS_DEFAULT_DNS}" != "1" ]; then
-		servers="${TUN_DNS}"
-		[ "$DNS_MODE" != "chinadns-ng" ] && servers="${LOCAL_DNS}"
-		cat <<-EOF > "/var/dnsmasq.d/dnsmasq-${CONFIG}.conf"
+	if [ "${DNS_MODE}" != "nouse" ] || [ "${IS_DEFAULT_DNS}" != "1" ]; then
+		msg="ISP"
+		servers="${LOCAL_DNS}"
+		echo "conf-dir=${TMP_DNSMASQ_PATH}" > "/var/dnsmasq.d/dnsmasq-${CONFIG}.conf"
+		echo "conf-dir=$TMP_DNSMASQ_PATH" > "${DNSMASQ_PATH}/dnsmasq-${CONFIG}.conf"
+
+		[ "${filtered_dns}" = "1" ] && servers="${TUN_DNS}"
+		[ "${DNS_MODE}" = "chinadns-ng" ] && servers="127.0.0.#${DNS_PORT}" && msg="chinadns-ng"
+		[ -n "${chnlist}" ] && msg="中国列表以外"
+		[ -n "${returnhome}" ] && msg="中国列表"
+		[ -n "${global}" ] && msg="全局"
+		if [ "${DNS_MODE}" = "other_dns" ]; then
+			msg="指定DNS"
+		else
+			[ "${IS_DEFAULT_DNS}" = "1" ] && [ "${filtered_dns}" != "1" ] && {
+				echolog "  - 不强制设置默认DNS(上级分配)！"
+				return
+			}
+		fi
+		cat <<-EOF >> "/var/dnsmasq.d/dnsmasq-${CONFIG}.conf"
 			$(echo "${servers}" | sed 's/,/\n/g' | gen_dnsmasq_items)
 			all-servers
 			no-poll
 			no-resolv
 		EOF
-		echolog "  - 默认DNS：${servers}"
+		echolog "  - [$?]以上所列以外及默认(${msg})：${servers}"
 	else
-		[ -z "${DEFAULT_DNS}" ] && {
+		echolog "  - 从系统 dnsmasq 自行手动处理..."
+		[ -z "$DEFAULT_DNS" ] && {
 			local tmp=$(get_host_ip ipv4 www.baidu.com 1)
 			[ -z "$tmp" ] && {
 				cat <<-EOF > /var/dnsmasq.d/dnsmasq-$CONFIG.conf
@@ -769,13 +810,11 @@ add_dnsmasq() {
 					no-poll
 					no-resolv
 				EOF
-				echolog "  - 你没有设置接口DNS，请前往设置！"
+				echolog "  - [$?]发现暂时无法解析度娘域名，临时接管并设置默认上游DNS：$(get_first_dns LOCAL_DNS 53)"
+				return 99
 			}
 		}
 	fi
-	
-	echo "conf-dir=$TMP_DNSMASQ_PATH" >> /var/dnsmasq.d/dnsmasq-$CONFIG.conf
-	cp -rf /var/dnsmasq.d/dnsmasq-$CONFIG.conf $DNSMASQ_PATH/dnsmasq-$CONFIG.conf
 }
 
 gen_pdnsd_config() {
@@ -881,7 +920,7 @@ start_haproxy() {
 		    maxconn                 3000
 
 	EOF
-			
+
 	items=$(get_enabled_anonymous_secs "@haproxy_config")
 	for item in $items; do
 		lport=$(config_n_get ${item} haproxy_port 0)

--- a/lienol/luci-app-passwall/root/usr/share/passwall/iptables.sh
+++ b/lienol/luci-app-passwall/root/usr/share/passwall/iptables.sh
@@ -82,13 +82,13 @@ get_action_chain_name() {
 		echo "全局代理"
 		;;
 	gfwlist)
-		echo "GFW名单"
+		echo "防火墙列表"
 		;;
 	chnroute)
-		echo "大陆白名单"
+		echo "中国列表以外"
 		;;
 	returnhome)
-		echo "回国模式"
+		echo "中国列表"
 		;;
 	esac
 }


### PR DESCRIPTION
+ rules for name servers follow main proxy modes
- remove the confusing 'dnsbyisp' option
* recommend chnroute mode for users behind the GFW, and don't use chinadns-ng this way if do care about DNS leaking on domains not in lists.

Signed-off-by: peter-tank <30540412+peter-tank@users.noreply.github.com>