### PR TITLE
配置变更频繁重启，可能导致存在多条相同规则

### DIFF
--- a/luci-app-passwall/Makefile
+++ b/luci-app-passwall/Makefile
@@ -134,8 +134,10 @@ define Package/$(PKG_NAME)/conffiles
 /etc/config/passwall_server
 /usr/share/passwall/rules/proxy_host
 /usr/share/passwall/rules/proxy_ip
-/usr/share/passwall/rules/direct_host
-/usr/share/passwall/rules/direct_ip
+/usr/share/passwall/rules/proxy_host2
+/usr/share/passwall/rules/proxy_ip2
+/usr/share/passwall/rules/proxy_host3
+/usr/share/passwall/rules/proxy_ip3
 endef
 
 define Package/$(PKG_NAME)/install

--- a/luci-app-passwall/luasrc/model/cbi/passwall/client/rule_list.lua
+++ b/luci-app-passwall/luasrc/model/cbi/passwall/client/rule_list.lua
@@ -2,7 +2,10 @@ local fs = require "nixio.fs"
 local appname = "passwall"
 
 m = Map(appname)
-
+m.apply_on_parse=true
+function m.on_apply(self)
+luci.sys.call("/etc/init.d/passwall reload > /dev/null 2>&1 &")
+end
 -- [[ Rule List Settings ]]--
 s = m:section(TypedSection, "global_rules")
 s.anonymous = true

--- a/luci-app-passwall/root/usr/share/passwall/subscribe.lua
+++ b/luci-app-passwall/root/usr/share/passwall/subscribe.lua
@@ -606,7 +606,6 @@ local function curl(url)
 end
 
 local function truncate_nodes()
-	local is_stop = 0
 	local function clear(type)
 		local node_num = ucic2:get(application, "@global_other[0]", type .. "_node_num") or 1
 		for i = 1, node_num, 1 do
@@ -614,7 +613,6 @@ local function truncate_nodes()
 			if node then
 				local is_sub_node = ucic2:get(application, node, "is_sub") or 0
 				if is_sub_node == "1" then
-					is_stop = 1
 					ucic2:set(application, '@global[0]', type .. "_node" .. i, "nil")
 				end
 			end
@@ -628,7 +626,6 @@ local function truncate_nodes()
 		if node then
 			local is_sub_node = ucic2:get(application, node, "is_sub") or 0
 			if is_sub_node == "1" then
-				is_stop = 1
 				ucic2:set(application, t[".name"], "node", "nil")
 			end
 		end
@@ -641,9 +638,6 @@ local function truncate_nodes()
 	end)
 	ucic2:commit(application)
 
-	if is_stop == 1 then
-		luci.sys.call("/etc/init.d/" .. application .. " restart > /dev/null 2>&1 &") -- 不加&的话日志会出现的更早
-	end
 	log('在线订阅节点已全部删除')
 end
 
@@ -808,7 +802,7 @@ local function update_node(manual)
 		]]--
 
 		ucic2:commit(application)
-		luci.sys.call("/etc/init.d/" .. application .. " restart > /dev/null 2>&1 &") -- 不加&的话日志会出现的更早
+		--luci.sys.call("/etc/init.d/" .. application .. " restart > /dev/null 2>&1 &") -- 不加&的话日志会出现的更早
 	end
 end
 


### PR DESCRIPTION
1. 使用循环清理所有残留，检测简化为其中一种规则存在时则继续清理
2. 防火墙变更时整个应用重新载入，现有设计不足以生成passwall.include时PSW规则在prerouting_rule之后