### PR TITLE
luci-app-passwall: drop non-exsit option for Trojan-Go sharelink

### DIFF
--- a/luci-app-passwall/luasrc/view/passwall/node_list/link_share_man.htm
+++ b/luci-app-passwall/luasrc/view/passwall/node_list/link_share_man.htm
@@ -180,11 +180,11 @@ local api = require "luci.model.cbi.passwall.api.api"
 				"@" + v_server.value +
 				":" + v_port.value + "/?";
 			if (opt.get("tls").checked) {
-				url += "tls=1";
 				url += opt.query("sni", "tls_serverName");
-				url += opt.query("allowinsecure", "tls_allowInsecure");
-			} else if (v_type === "Trojan-Go") {
-				url += "tls=0";
+				if (v_type !== "Trojan-Go") {
+					url += "tls=1"
+					url += opt.query("allowinsecure", "tls_allowInsecure");
+				}
 			}
 			if (v_type === "Trojan-Go") {
 				if (!opt.get("tls").checked && opt.get("trojan_transport").value === "original") {
@@ -214,7 +214,6 @@ local api = require "luci.model.cbi.passwall.api.api"
 						":" + opt.get("ss_aead_pwd").value;
 				}
 				url += "&encryption=" + encodeURIComponent(enc);
-				url += opt.query("mux", "mux");
 			}
 			url += "#" + encodeURI(v_alias.value);
 		}
@@ -492,8 +491,10 @@ local api = require "luci.model.cbi.passwall.api.api"
 			opt.set('address', m.hostname);
 			opt.set('port', m.port || "443");
 			opt.set(opt.client ? 'password' : 'passwords', decodeURIComponent(password));
-			opt.set('tls', (queryParam.tls && queryParam.tls === '1'));
+			opt.set('tls', '1');
 			opt.get('tls').dispatchEvent(event);
+			opt.set('tls_allowInsecure', '0');
+			opt.set('tls_serverName', queryParam.peer || queryParam.sni || '');
 			var plugin = queryParam.plugin !== undefined;
 			if (plugin) {
 				opt.set('trojan_transport', 'original');
@@ -509,13 +510,6 @@ local api = require "luci.model.cbi.passwall.api.api"
 					}
 				} else
 					alert(queryParam.plugin);
-			}
-			var tls = !plugin && queryParam.tls === '1';
-			opt.set('tls', tls);
-			opt.get('tls').dispatchEvent(event);
-			if (tls) {
-				opt.set('tls_serverName', queryParam.peer || queryParam.sni || '');
-				opt.set('tls_allowInsecure', queryParam.allowinsecure === '1');
 			}
 			var tran = 'original';
 			var or = queryParam.type === undefined || queryParam.type === 'original';
@@ -549,7 +543,7 @@ local api = require "luci.model.cbi.passwall.api.api"
 				opt.set('ss_aead_method', enc.method.toLowerCase() || '');
 				opt.set('ss_aead_pwd', enc.password || '');
 			}
-			opt.set('mux', queryParam.mux === '1');
+			opt.set('mux', '1');
 			if (m.hash) {
 				opt.set('remarks', decodeURI(m.hash.substr(1)));
 			}

--- a/luci-app-passwall/root/usr/share/passwall/subscribe.lua
+++ b/luci-app-passwall/root/usr/share/passwall/subscribe.lua
@@ -473,7 +473,6 @@ local function processData(szType, content, add_mode)
 			end
 			if params.peer then peer = params.peer end
 			sni = params.sni and params.sni or ""
-			if params.mux and params.mux == "1" then result.mux = "1" end
 			if params.ws and params.ws == "1" then
 				result.trojan_transport = "ws"
 				if params.wshost then result.ws_host = params.wshost end
@@ -486,9 +485,10 @@ local function processData(szType, content, add_mode)
 				if params.sspasswd then result.ss_aead_pwd = params.sspasswd end
 			end
 			result.port = port
-			if result.mux or result.trojan_transport == "ws" or result.ss_aead then
+			if result.trojan_transport == "ws" or result.ss_aead then
 				result.type = "Trojan-Go"
 				result.fingerprint = "firefox"
+				result.mux = "1"
 			end
 			result.tls = '1'
 			result.tls_serverName = peer and peer or sni
@@ -525,19 +525,14 @@ local function processData(szType, content, add_mode)
 				result.address = hostInfo and hostInfo[1] or Info[2]
 			end
 			local peer, sni = nil, ""
-			local allowInsecure = allowInsecure_default
 			local query = split(Info[2], "?")
 			local params = {}
 			for _, v in pairs(split(query[2], '&')) do
 				local t = split(v, '=')
 				params[string.lower(t[1])] = UrlDecode(t[2])
 			end
-			if params.allowinsecure then
-				allowInsecure = params.allowinsecure
-			end
 			if params.peer then peer = params.peer end
 			sni = params.sni and params.sni or ""
-			if params.mux and params.mux == "1" then result.mux = "1" end
 			if params.type and params.type == "ws" then
 				result.trojan_transport = "ws"
 				if params.host then result.ws_host = params.host end
@@ -551,9 +546,10 @@ local function processData(szType, content, add_mode)
 			end
 			result.port = port
 			result.fingerprint = "firefox"
-			result.tls = '1'
+			result.tls = "1"
 			result.tls_serverName = peer and peer or sni
-			result.tls_allowInsecure = allowInsecure and "1" or "0"
+			result.tls_allowInsecure = "0"
+			result.mux = "1"
 		end
 	elseif szType == "ssd" then
 		result.type = "SS"


### PR DESCRIPTION
Referred from https://p4gefau1t.github.io/trojan-go/developer/url/, `tls`,
`allowInsecure` and `mux` are not exsited on the sharelink of Trojan-Go.

Reported-by: DuckSoft <realducksoft@gmail.com>
Signed-off-by: Tianling Shen <cnsztl@project-openwrt.eu.org>