### PR TITLE
luci-app-passwall: global option always_use_chinadns_ng

### DIFF
--- a/luci-app-passwall/root/usr/share/passwall/app.sh
+++ b/luci-app-passwall/root/usr/share/passwall/app.sh
@@ -801,7 +801,8 @@ start_dns() {
 	nonuse)
 		echolog "  - 不过滤DNS..."
 		TUN_DNS=""
-		return
+		use_chinadns_ng=$(config_t_get global always_use_chinadns_ng 0)
+		[ "$use_chinadns_ng" == "0" ] && return
 	;;
 	dns2socks)
 		local dns2socks_socks_server=$(echo $(config_t_get global socks_server 127.0.0.1:9050) | sed "s/#/:/g")


### PR DESCRIPTION
Issue #1103 的上一份PR在DNS选项为nonuse时总是不启动chinadns-ng，影响到我这种需要有passwall启动chinadns-ng并更新其相关数据，以及应用代理域名表和域名白名单功能的。为了兼顾双方的需要，增加了一个选项。

按上一份PR的逻辑，默认行为是不运行chinadns-ng，无需任何设置。

需要有passwall来运行chinadns-ng，在7913端口提供smartdns进行解析，则需自行修改配置文件
/etc/config/passwall中global小节增加项目always_use_chinadns_ng。
```
config global
        option always_use_chinadns_ng '1'
```
