### PR TITLE
Retry all errors when test url

### DIFF
--- a/luci-app-passwall/root/usr/share/passwall/test.sh
+++ b/luci-app-passwall/root/usr/share/passwall/test.sh
@@ -28,7 +28,7 @@ test_url() {
 	local timeout=2
 	[ -n "$3" ] && timeout=$3
 	local extra_params=$4
-	status=$(/usr/bin/curl -I -o /dev/null -skL $extra_params --connect-timeout $timeout --retry $try -w %{http_code} "$url")
+	status=$(/usr/bin/curl -I -o /dev/null -skL $extra_params --connect-timeout $timeout --retry $try --retry-all-errors -w %{http_code} "$url")
 	case "$status" in
 		204|\
 		200)


### PR DESCRIPTION
curl如果不加--retry-all-errors参数，遇到有些网络错误的时候--retry参数不起作用会直接返回，会引起机场抽风1秒钟也被判定为节点异常，导致频繁自动切换节点。

加入--retry-all-errors参数后任意错误都不影响重试，节点异常判断更加准确。