### PR TITLE
Update chinadns-ng option

### DIFF
--- a/luci-app-passwall/root/usr/share/passwall/app.sh
+++ b/luci-app-passwall/root/usr/share/passwall/app.sh
@@ -1190,7 +1190,7 @@ start_dns() {
 			cat "${RULES_PATH}/direct_host" >> "${chnlist_param}"
 			echolog "  | - [$?](chinadns-ng) 域名白名单合并到中国域名表"
 		}
-		chnlist_param=${chnlist_param:+-m "${chnlist_param}" -M}
+		chnlist_param=${chnlist_param:+-m "${chnlist_param}"}
 		local log_path="${TMP_PATH}/chinadns-ng.log"
 		log_path="/dev/null"
 		ln_start_bin "$(first_type chinadns-ng)" chinadns-ng "$log_path" -v -b 0.0.0.0 -l "${china_ng_listen_port}" ${china_ng_chn:+-c "${china_ng_chn}"} ${chnlist_param} ${china_ng_gfw:+-t "${china_ng_gfw}"} ${gfwlist_param:+-g "${gfwlist_param}"} -f


### PR DESCRIPTION
I noticed there are several domain listed both in the chnlist and gfwlist.
By default, chinadns-ng will use the gfwlist IP instead of the chlist one and that's also the whole logic behind chinadns-ng.
However, passwall now uses the -M option which prefers the chnlist IP whenever there is a conflict in "chnroute mode". Let's fix this by updating the chinadns-ng option.

I list those domains which are added to both chnlist and gfwlist in dnsmasq ipset.conf here.
ipset=/.googlesyndication.com/gfwlist,gfwlist6,chnroute,chnroute6
ipset=/.googleadservices.com/gfwlist,gfwlist6,chnroute,chnroute6
ipset=/.2mdn.net/gfwlist,gfwlist6,chnroute,chnroute6
ipset=/.alibabacloud.com/gfwlist,gfwlist6,chnroute,chnroute6
ipset=/.cnpmjs.org/gfwlist,gfwlist6,chnroute,chnroute6
ipset=/.doubleclick.net/gfwlist,gfwlist6,chnroute,chnroute6
ipset=/.gigabyte.com/gfwlist,gfwlist6,chnroute,chnroute6
ipset=/.galaxyappstore.com/gfwlist,gfwlist6,chnroute,chnroute6
ipset=/.openresty.org/gfwlist,gfwlist6,chnroute,chnroute6
ipset=/.joox.com/gfwlist,gfwlist6,chnroute,chnroute6
ipset=/.globalsign.com/gfwlist,gfwlist6,chnroute,chnroute6
ipset=/.sci-hub.ee/gfwlist,gfwlist6,chnroute,chnroute6
ipset=/.app-measurement.com/gfwlist,gfwlist6,chnroute,chnroute6
ipset=/.googletagmanager.com/gfwlist,gfwlist6,chnroute,chnroute6
ipset=/.kuke.com/gfwlist,gfwlist6,chnroute,chnroute6
ipset=/.quantil.com/gfwlist,gfwlist6,chnroute,chnroute6
ipset=/.myfun.com/gfwlist,gfwlist6,chnroute,chnroute6
ipset=/.zoom.us/gfwlist,gfwlist6,chnroute,chnroute6
ipset=/.yshyqxx.com/gfwlist,gfwlist6,chnroute,chnroute6
ipset=/.googleoptimize.com/gfwlist,gfwlist6,chnroute,chnroute6
ipset=/.googleanalytics.com/gfwlist,gfwlist6,chnroute,chnroute6
ipset=/.googletagservices.com/gfwlist,gfwlist6,chnroute,chnroute6
ipset=/.google-analytics.com/gfwlist,gfwlist6,chnroute,chnroute6