### PR TITLE
修复全局UDP代理DNS问题

### DIFF
--- a/luci-app-passwall/root/usr/share/passwall/iptables.sh
+++ b/luci-app-passwall/root/usr/share/passwall/iptables.sh
@@ -20,6 +20,8 @@ IPSET_BLOCKLIST6="blocklist6"
 
 FORCE_INDEX=2
 
+. /lib/functions/network.sh
+
 ipt_n="iptables -t nat -w"
 ipt_m="iptables -t mangle -w"
 ip6t_n="ip6tables -t nat -w"
@@ -153,6 +155,28 @@ gen_laniplist() {
 
 gen_laniplist_6() {
 	cat $RULES_PATH/lanlist_ipv6 | tr -s '\n' | grep -v "^#"
+}
+
+get_wan_ip() {
+	local NET_IF
+	local NET_ADDR
+	
+	network_flush_cache
+	network_find_wan NET_IF
+	network_get_ipaddr NET_ADDR "${NET_IF}"
+	
+	echo $NET_ADDR
+}
+
+get_wan6_ip() {
+	local NET_IF
+	local NET_ADDR
+	
+	network_flush_cache
+	network_find_wan6 NET_IF
+	network_get_ipaddr6 NET_ADDR "${NET_IF}"
+	
+	echo $NET_ADDR
 }
 
 load_acl() {
@@ -763,6 +787,10 @@ add_firewall_rule() {
 	$ipt_m -A PSW -m mark --mark 0xff -j RETURN
 	$ipt_m -A PSW $(dst $IPSET_BLOCKLIST) -j DROP
 	
+	WAN_IP=$(get_wan_ip)
+	[ ! -z "${WAN_IP}" ] && $ipt_m -A PSW $(comment "WAN_IP_RETURN") -d "${WAN_IP}" -j RETURN
+	unset WAN_IP
+	
 	PR_INDEX=$((PR_INDEX + 1))
 	$ipt_m -I PREROUTING $PR_INDEX -j PSW
 	unset PR_INDEX
@@ -805,6 +833,10 @@ add_firewall_rule() {
 	$ip6t_m -A PSW $(dst $IPSET_WHITELIST6) -j RETURN
 	$ip6t_m -A PSW -m mark --mark 0xff -j RETURN
 	$ip6t_m -A PSW $(dst $IPSET_BLOCKLIST6) -j DROP
+	
+	WAN6_IP=$(get_wan6_ip)
+	[ ! -z "${WAN6_IP}" ] && $ip6t_m -A PSW $(comment "WAN6_IP_RETURN") -d ${WAN6_IP} -j RETURN
+	unset WAN6_IP
 
 	PR_INDEX=$((PR_INDEX + 1))
 	$ip6t_m -I PREROUTING $PR_INDEX -j PSW
@@ -1078,6 +1110,12 @@ gen_include() {
 		PR_INDEX=\$((PR_INDEX + 1))
 		$ipt_m -I PREROUTING \$PR_INDEX -j PSW
 		
+		PR_INDEX=\$(/usr/share/passwall/iptables.sh RULE_LAST_INDEX "$ipt_m" PSW WAN_IP_RETURN -1)
+		if [ \$PR_INDEX -ge 0 ]; then
+			WAN_IP=\$(/usr/share/passwall/iptables.sh get_wan_ip)
+			[ ! -z "\${WAN_IP}" ] && $ipt_m -R PSW \$PR_INDEX $(comment "WAN_IP_RETURN") -d "\${WAN_IP}" -j RETURN
+		fi
+		
 		[ "$accept_icmpv6" = "1" ] && $ip6t_n -A PREROUTING -p ipv6-icmp -j PSW
 		
 		PR_INDEX=\$(/usr/share/passwall/iptables.sh RULE_LAST_INDEX "$ip6t_m" PREROUTING mwan3 1)
@@ -1085,6 +1123,12 @@ gen_include() {
 		
 		PR_INDEX=\$((PR_INDEX + 1))
 		$ip6t_m -I PREROUTING \$PR_INDEX -j PSW
+		
+		PR_INDEX=\$(/usr/share/passwall/iptables.sh RULE_LAST_INDEX "$ip6t_m" PSW WAN6_IP_RETURN -1)
+		if [ \$PR_INDEX -ge 0 ]; then
+			WAN6_IP=\$(/usr/share/passwall/iptables.sh get_wan6_ip)
+			[ ! -z "\${WAN6_IP}" ] && $ip6t_m -R PSW \$PR_INDEX $(comment "WAN6_IP_RETURN") -d "\${WAN6_IP}" -j RETURN
+		fi
 	EOF
 	return 0
 }
@@ -1106,6 +1150,12 @@ RULE_LAST_INDEX)
 	;;
 flush_ipset)
 	flush_ipset
+	;;
+get_wan_ip)
+	get_wan_ip
+	;;
+get_wan6_ip)
+	get_wan6_ip
 	;;
 stop)
 	stop


### PR DESCRIPTION
目前的版本开启全局UDP代理，无论是否开启路由器本身的UDP代理，均会出现国内DNS无法使用UDP查询的现象。但大陆白名单模式一切正常。

抓包后发现，原因是DNS的UDP回复被mangle表的TPROXY规则匹配，发往代理。在大陆白名单模式下，由于回复包的目的IP为WAN IP（大陆IP），被RETURN放行，所以不会触发bug。

此PR修改的内容：

针对IPv4和IPv6，自动获取主网络接口的IP，并且添加目的地为此IP，在mangle表里的RETURN规则。

测试：

- [X] IPv4 NAT下路由器DNS查询
- [X] IPv4 NAT下子网内设备DNS查询
- [X] IPv6 路由器DNS查询 （IPv6 NAT未测试）
- [X] IPv6 子网内设备DNS查询（此情况不触发bug）

注：获取WAN IP的方式参考了https://openwrt.org/docs/guide-developer/network-scripting#get_wan_address