### PR TITLE
luci: fix typo for route_only default value

### DIFF
--- a/luci-app-passwall/luasrc/model/cbi/passwall/client/other.lua
+++ b/luci-app-passwall/luasrc/model/cbi/passwall/client/other.lua
@@ -115,7 +115,7 @@ o:depends("ipv6_tproxy", true)
 o.default = 0
 
 o = s:option(Flag, "route_only", translate("Sniffing Route Only (V2Ray/Xray)"))
-o.default = 1
+o.default = "1"
 
 --[[
 ---- TCP Redir Port


### PR DESCRIPTION
Fix typo for route_only default value.

When updated from previous config, route only flag in luci was unchecked, while the routeOnly is 1 in v2ray/xray as default value.

This PR resolves the issue mentioned above.