### PR TITLE
Add nonuse DNS option

### DIFF
--- a/luci-app-passwall/luasrc/model/cbi/passwall/client/global.lua
+++ b/luci-app-passwall/luasrc/model/cbi/passwall/client/global.lua
@@ -207,6 +207,7 @@ if has_xray then
     dns_mode:value("xray", "Xray")
 end
 dns_mode:value("udp", translatef("Requery DNS By %s", "UDP"))
+dns_mode:value("nonuse", translate("No Filter"))
 
 o = s:taboption("DNS", ListValue, "v2ray_dns_mode", " ")
 o:value("tcp", "TCP")
@@ -302,6 +303,7 @@ o.rmempty = false
 if has_chnlist and api.is_finded("chinadns-ng") then
     o = s:taboption("DNS", Flag, "chinadns_ng", translate("ChinaDNS-NG"), translate("The effect is better, but will increase the memory."))
     o.default = "0"
+    o:depends({dns_mode = "nonuse", ["!reverse"] = true})
     o:depends({dns_mode = "dns2socks"})
     o:depends({dns_mode = "pdnsd"})
     o:depends({dns_mode = "v2ray", v2ray_dns_mode = "tcp"})

--- a/luci-app-passwall/po/zh-cn/passwall.po
+++ b/luci-app-passwall/po/zh-cn/passwall.po
@@ -154,6 +154,9 @@ msgstr "你只需要在SmartDNS配置好国内DNS分组，并设置重定向或�
 msgid "Filter Mode"
 msgstr "过滤模式"
 
+msgid "No Filter"
+msgstr "不过滤"
+
 msgid "TCP node must be '%s' type to use FakeDNS."
 msgstr "TCP节点必须是 '%s' 类型才能使用 FakeDNS。"
 

--- a/luci-app-passwall/root/usr/share/passwall/app.sh
+++ b/luci-app-passwall/root/usr/share/passwall/app.sh
@@ -1050,6 +1050,11 @@ start_dns() {
 	echolog "过滤服务配置：准备接管域名解析..."
 
 	case "$DNS_MODE" in
+	nonuse)
+		echolog "  - 不过滤DNS..."
+		TUN_DNS=""
+		return
+	;;
 	dns2socks)
 		local dns2socks_socks_server=$(echo $(config_t_get global socks_server 127.0.0.1:1080) | sed "s/#/:/g")
 		local dns2socks_forward=$(get_first_dns DNS_FORWARD 53 | sed 's/#/:/g')

--- a/luci-app-passwall/root/usr/share/passwall/helper_dnsmasq.sh
+++ b/luci-app-passwall/root/usr/share/passwall/helper_dnsmasq.sh
@@ -123,150 +123,156 @@ add() {
 	mkdir -p "${TMP_DNSMASQ_PATH}" "${DNSMASQ_PATH}" "/tmp/dnsmasq.d"
 	count_hosts_str="!"
 
-	#屏蔽列表
-	[ -s "${RULES_PATH}/block_host" ] && {
-		cat "${RULES_PATH}/block_host" | tr -s '\n' | grep -v "^#" | sort -u | gen_address_items address="0.0.0.0" outf="${TMP_DNSMASQ_PATH}/00-block_host.conf"
-	}
+	if [ "${DNS_MODE}" = "nonuse" ]; then
+		echolog "  - 不对域名进行分流解析"
+		LOG_FILE=${_LOG_FILE}
+		return 0
+	else
+		#屏蔽列表
+		[ -s "${RULES_PATH}/block_host" ] && {
+			cat "${RULES_PATH}/block_host" | tr -s '\n' | grep -v "^#" | sort -u | gen_address_items address="0.0.0.0" outf="${TMP_DNSMASQ_PATH}/00-block_host.conf"
+		}
 
-	#始终用国内DNS解析节点域名
-	fwd_dns="${LOCAL_DNS}"
-	servers=$(uci show "${CONFIG}" | grep ".address=" | cut -d "'" -f 2)
-	hosts_foreach "servers" host_from_url | grep '[a-zA-Z]$' | sort -u | gen_items ipsets="vpsiplist,vpsiplist6" dnss="${fwd_dns}" outf="${TMP_DNSMASQ_PATH}/10-vpsiplist_host.conf" ipsetoutf="${TMP_DNSMASQ_PATH}/ipset.conf"
-	echolog "  - [$?]节点列表中的域名(vpsiplist)：${fwd_dns:-默认}"
-
-	#始终用国内DNS解析直连（白名单）列表
-	[ -s "${RULES_PATH}/direct_host" ] && {
+		#始终用国内DNS解析节点域名
 		fwd_dns="${LOCAL_DNS}"
-		#[ -n "$CHINADNS_DNS" ] && unset fwd_dns
-		cat "${RULES_PATH}/direct_host" | tr -s '\n' | grep -v "^#" | sort -u | gen_items ipsets="whitelist,whitelist6" dnss="${fwd_dns}" outf="${TMP_DNSMASQ_PATH}/11-direct_host.conf" ipsetoutf="${TMP_DNSMASQ_PATH}/ipset.conf"
-		echolog "  - [$?]域名白名单(whitelist)：${fwd_dns:-默认}"
-	}
-	
-	subscribe_list=""
-	for item in $(get_enabled_anonymous_secs "@subscribe_list"); do
-		host=$(host_from_url "$(config_n_get ${item} url)")
-		subscribe_list="${subscribe_list}\n${host}"
-	done
-	[ -n "$subscribe_list" ] && {
-		if [ "$(config_t_get global_subscribe subscribe_proxy 0)" = "0" ]; then
-			#如果没有开启通过代理订阅
+		servers=$(uci show "${CONFIG}" | grep ".address=" | cut -d "'" -f 2)
+		hosts_foreach "servers" host_from_url | grep '[a-zA-Z]$' | sort -u | gen_items ipsets="vpsiplist,vpsiplist6" dnss="${fwd_dns}" outf="${TMP_DNSMASQ_PATH}/10-vpsiplist_host.conf" ipsetoutf="${TMP_DNSMASQ_PATH}/ipset.conf"
+		echolog "  - [$?]节点列表中的域名(vpsiplist)：${fwd_dns:-默认}"
+
+		#始终用国内DNS解析直连（白名单）列表
+		[ -s "${RULES_PATH}/direct_host" ] && {
 			fwd_dns="${LOCAL_DNS}"
-			echo -e "$subscribe_list" | sort -u | gen_items ipsets="whitelist,whitelist6" dnss="${fwd_dns}" outf="${TMP_DNSMASQ_PATH}/12-subscribe.conf" ipsetoutf="${TMP_DNSMASQ_PATH}/ipset.conf"
-			echolog "  - [$?]节点订阅域名(whitelist)：${fwd_dns:-默认}"
-		else
-			#如果开启了通过代理订阅
-			fwd_dns="${TUN_DNS}"
+			#[ -n "$CHINADNS_DNS" ] && unset fwd_dns
+			cat "${RULES_PATH}/direct_host" | tr -s '\n' | grep -v "^#" | sort -u | gen_items ipsets="whitelist,whitelist6" dnss="${fwd_dns}" outf="${TMP_DNSMASQ_PATH}/11-direct_host.conf" ipsetoutf="${TMP_DNSMASQ_PATH}/ipset.conf"
+			echolog "  - [$?]域名白名单(whitelist)：${fwd_dns:-默认}"
+		}
+
+		subscribe_list=""
+		for item in $(get_enabled_anonymous_secs "@subscribe_list"); do
+			host=$(host_from_url "$(config_n_get ${item} url)")
+			subscribe_list="${subscribe_list}\n${host}"
+		done
+		[ -n "$subscribe_list" ] && {
+			if [ "$(config_t_get global_subscribe subscribe_proxy 0)" = "0" ]; then
+				#如果没有开启通过代理订阅
+				fwd_dns="${LOCAL_DNS}"
+				echo -e "$subscribe_list" | sort -u | gen_items ipsets="whitelist,whitelist6" dnss="${fwd_dns}" outf="${TMP_DNSMASQ_PATH}/12-subscribe.conf" ipsetoutf="${TMP_DNSMASQ_PATH}/ipset.conf"
+				echolog "  - [$?]节点订阅域名(whitelist)：${fwd_dns:-默认}"
+			else
+				#如果开启了通过代理订阅
+				fwd_dns="${TUN_DNS}"
+				local ipset_flag="blacklist,blacklist6"
+				if [ "${NO_PROXY_IPV6}" = "1" ]; then
+					ipset_flag="blacklist"
+					echo -e "$subscribe_list" | sort -u | gen_address_items address="::" outf="${TMP_DNSMASQ_PATH}/91-subscribe-noipv6.conf"
+				fi
+				[ -n "${REMOTE_FAKEDNS}" ] && unset ipset_flag
+				echo -e "$subscribe_list" | sort -u | gen_items ipsets="${ipset_flag}" dnss="${fwd_dns}" outf="${TMP_DNSMASQ_PATH}/91-subscribe.conf" ipsetoutf="${TMP_DNSMASQ_PATH}/ipset.conf"
+				echolog "  - [$?]节点订阅域名(blacklist)：${fwd_dns:-默认}"
+			fi
+		}
+
+		#始终使用远程DNS解析代理（黑名单）列表
+		[ -s "${RULES_PATH}/proxy_host" ] && {
 			local ipset_flag="blacklist,blacklist6"
 			if [ "${NO_PROXY_IPV6}" = "1" ]; then
 				ipset_flag="blacklist"
-				echo -e "$subscribe_list" | sort -u | gen_address_items address="::" outf="${TMP_DNSMASQ_PATH}/91-subscribe-noipv6.conf"
+				cat "${RULES_PATH}/proxy_host" | tr -s '\n' | grep -v "^#" | sort -u | gen_address_items address="::" outf="${TMP_DNSMASQ_PATH}/97-proxy_host-noipv6.conf"
 			fi
+			fwd_dns="${TUN_DNS}"
 			[ -n "${REMOTE_FAKEDNS}" ] && unset ipset_flag
-			echo -e "$subscribe_list" | sort -u | gen_items ipsets="${ipset_flag}" dnss="${fwd_dns}" outf="${TMP_DNSMASQ_PATH}/91-subscribe.conf" ipsetoutf="${TMP_DNSMASQ_PATH}/ipset.conf"
-			echolog "  - [$?]节点订阅域名(blacklist)：${fwd_dns:-默认}"
-		fi
-	}
+			cat "${RULES_PATH}/proxy_host" | tr -s '\n' | grep -v "^#" | sort -u | gen_items ipsets="${ipset_flag}" dnss="${fwd_dns}" outf="${TMP_DNSMASQ_PATH}/97-proxy_host.conf" ipsetoutf="${TMP_DNSMASQ_PATH}/ipset.conf"
+			echolog "  - [$?]代理域名表(blacklist)：${fwd_dns:-默认}"
+		}
+
+		#分流规则
+		[ "$(config_n_get $TCP_NODE protocol)" = "_shunt" ] && {
+			fwd_dns="${TUN_DNS}"
+			msg_dns="${fwd_dns}"
+			local default_node_id=$(config_n_get $TCP_NODE default_node _direct)
+			local shunt_ids=$(uci show $CONFIG | grep "=shunt_rules" | awk -F '.' '{print $2}' | awk -F '=' '{print $1}')
+			for shunt_id in $shunt_ids; do
+				local shunt_node_id=$(config_n_get $TCP_NODE ${shunt_id} nil)
+				[ "$shunt_node_id" = "nil" ] && continue
+				[ "$shunt_node_id" = "_default" ] && shunt_node_id=$default_node_id
+				[ "$shunt_node_id" = "_blackhole" ] && continue
+				local str=$(echo -n $(config_n_get $shunt_id domain_list | grep -v 'regexp:\|geosite:\|ext:' | sed 's/domain:\|full:\|//g' | tr -s "\r\n" "\n" | sort -u) | sed "s/ /|/g")
+				[ -n "$str" ] && count_hosts_str="${count_hosts_str}|${str}"
+				[ "$shunt_node_id" = "_direct" ] && {
+					[ -n "$str" ] && echo $str | sed "s/|/\n/g" | gen_items ipsets="whitelist,whitelist6" "${LOCAL_DNS}" "${TMP_DNSMASQ_PATH}/13-shunt_host.conf"
+					msg_dns="${LOCAL_DNS}"
+					continue
+				}
+				local shunt_node=$(config_n_get $shunt_node_id address nil)
+				[ "$shunt_node" = "nil" ] && continue
+
+				[ -n "$str" ] && {
+					local ipset_flag="shuntlist,shuntlist6"
+					if [ "${NO_PROXY_IPV6}" = "1" ]; then
+						ipset_flag="shuntlist"
+						echo $str | sed "s/|/\n/g" | gen_address_items address="::" outf="${TMP_DNSMASQ_PATH}/98-shunt_host-noipv6.conf"
+					fi
+					[ -n "${REMOTE_FAKEDNS}" ] && unset ipset_flag
+					echo $str | sed "s/|/\n/g" | gen_items ipsets="${ipset_flag}" dnss="${fwd_dns}" outf="${TMP_DNSMASQ_PATH}/98-shunt_host.conf" ipsetoutf="${TMP_DNSMASQ_PATH}/ipset.conf"
+					msg_dns="${fwd_dns}"
+				}
+			done
+			echolog "  - [$?]V2ray/Xray分流规则(shuntlist)：${msg_dns:-默认}"
+		}
 	
-	#始终使用远程DNS解析代理（黑名单）列表
-	[ -s "${RULES_PATH}/proxy_host" ] && {
-		local ipset_flag="blacklist,blacklist6"
-		if [ "${NO_PROXY_IPV6}" = "1" ]; then
-			ipset_flag="blacklist"
-			cat "${RULES_PATH}/proxy_host" | tr -s '\n' | grep -v "^#" | sort -u | gen_address_items address="::" outf="${TMP_DNSMASQ_PATH}/97-proxy_host-noipv6.conf"
-		fi
-		fwd_dns="${TUN_DNS}"
-		[ -n "${REMOTE_FAKEDNS}" ] && unset ipset_flag
-		cat "${RULES_PATH}/proxy_host" | tr -s '\n' | grep -v "^#" | sort -u | gen_items ipsets="${ipset_flag}" dnss="${fwd_dns}" outf="${TMP_DNSMASQ_PATH}/97-proxy_host.conf" ipsetoutf="${TMP_DNSMASQ_PATH}/ipset.conf"
-		echolog "  - [$?]代理域名表(blacklist)：${fwd_dns:-默认}"
-	}
+		[ -s "${RULES_PATH}/direct_host" ] && direct_hosts_str="$(echo -n $(cat ${RULES_PATH}/direct_host | tr -s '\n' | grep -v "^#" | sort -u) | sed "s/ /|/g")"
+		[ -s "${RULES_PATH}/proxy_host" ] && proxy_hosts_str="$(echo -n $(cat ${RULES_PATH}/proxy_host | tr -s '\n' | grep -v "^#" | sort -u) | sed "s/ /|/g")"
+		[ -n "$direct_hosts_str" ] && count_hosts_str="${count_hosts_str}|${direct_hosts_str}"
+		[ -n "$proxy_hosts_str" ] && count_hosts_str="${count_hosts_str}|${proxy_hosts_str}"
 
-	#分流规则
-	[ "$(config_n_get $TCP_NODE protocol)" = "_shunt" ] && {
-		fwd_dns="${TUN_DNS}"
-		msg_dns="${fwd_dns}"
-		local default_node_id=$(config_n_get $TCP_NODE default_node _direct)
-		local shunt_ids=$(uci show $CONFIG | grep "=shunt_rules" | awk -F '.' '{print $2}' | awk -F '=' '{print $1}')
-		for shunt_id in $shunt_ids; do
-			local shunt_node_id=$(config_n_get $TCP_NODE ${shunt_id} nil)
-			[ "$shunt_node_id" = "nil" ] && continue
-			[ "$shunt_node_id" = "_default" ] && shunt_node_id=$default_node_id
-			[ "$shunt_node_id" = "_blackhole" ] && continue
-			local str=$(echo -n $(config_n_get $shunt_id domain_list | grep -v 'regexp:\|geosite:\|ext:' | sed 's/domain:\|full:\|//g' | tr -s "\r\n" "\n" | sort -u) | sed "s/ /|/g")
-			[ -n "$str" ] && count_hosts_str="${count_hosts_str}|${str}"
-			[ "$shunt_node_id" = "_direct" ] && {
-				[ -n "$str" ] && echo $str | sed "s/|/\n/g" | gen_items ipsets="whitelist,whitelist6" "${LOCAL_DNS}" "${TMP_DNSMASQ_PATH}/13-shunt_host.conf"
-				msg_dns="${LOCAL_DNS}"
-				continue
-			}
-			local shunt_node=$(config_n_get $shunt_node_id address nil)
-			[ "$shunt_node" = "nil" ] && continue
+		#如果没有使用回国模式
+		if [ -z "${returnhome}" ]; then
+			# GFW 模式
+			[ -s "${RULES_PATH}/gfwlist" ] && {
+				grep -v -E "$count_hosts_str" "${RULES_PATH}/gfwlist" > "${TMP_PATH}/gfwlist"
 
-			[ -n "$str" ] && {
-				local ipset_flag="shuntlist,shuntlist6"
+				local ipset_flag="gfwlist,gfwlist6"
 				if [ "${NO_PROXY_IPV6}" = "1" ]; then
-					ipset_flag="shuntlist"
-					echo $str | sed "s/|/\n/g" | gen_address_items address="::" outf="${TMP_DNSMASQ_PATH}/98-shunt_host-noipv6.conf"
+					ipset_flag="gfwlist"
+					sort -u "${TMP_PATH}/gfwlist" | gen_address_items address="::" outf="${TMP_DNSMASQ_PATH}/99-gfwlist-noipv6.conf"
 				fi
+				fwd_dns="${TUN_DNS}"
+				[ -n "$CHINADNS_DNS" ] && unset fwd_dns
 				[ -n "${REMOTE_FAKEDNS}" ] && unset ipset_flag
-				echo $str | sed "s/|/\n/g" | gen_items ipsets="${ipset_flag}" dnss="${fwd_dns}" outf="${TMP_DNSMASQ_PATH}/98-shunt_host.conf" ipsetoutf="${TMP_DNSMASQ_PATH}/ipset.conf"
-				msg_dns="${fwd_dns}"
+				sort -u "${TMP_PATH}/gfwlist" | gen_items ipsets="${ipset_flag}" dnss="${fwd_dns}" outf="${TMP_DNSMASQ_PATH}/99-gfwlist.conf" ipsetoutf="${TMP_DNSMASQ_PATH}/ipset.conf"
+				echolog "  - [$?]防火墙域名表(gfwlist)：${fwd_dns:-默认}"
+				rm -f "${TMP_PATH}/gfwlist"
 			}
-		done
-		echolog "  - [$?]V2ray/Xray分流规则(shuntlist)：${msg_dns:-默认}"
-	}
-	
-	[ -s "${RULES_PATH}/direct_host" ] && direct_hosts_str="$(echo -n $(cat ${RULES_PATH}/direct_host | tr -s '\n' | grep -v "^#" | sort -u) | sed "s/ /|/g")"
-	[ -s "${RULES_PATH}/proxy_host" ] && proxy_hosts_str="$(echo -n $(cat ${RULES_PATH}/proxy_host | tr -s '\n' | grep -v "^#" | sort -u) | sed "s/ /|/g")"
-	[ -n "$direct_hosts_str" ] && count_hosts_str="${count_hosts_str}|${direct_hosts_str}"
-	[ -n "$proxy_hosts_str" ] && count_hosts_str="${count_hosts_str}|${proxy_hosts_str}"
 
-	#如果没有使用回国模式
-	if [ -z "${returnhome}" ]; then
-		# GFW 模式
-		[ -s "${RULES_PATH}/gfwlist" ] && {
-			grep -v -E "$count_hosts_str" "${RULES_PATH}/gfwlist" > "${TMP_PATH}/gfwlist"
-			
-			local ipset_flag="gfwlist,gfwlist6"
-			if [ "${NO_PROXY_IPV6}" = "1" ]; then
-				ipset_flag="gfwlist"
-				sort -u "${TMP_PATH}/gfwlist" | gen_address_items address="::" outf="${TMP_DNSMASQ_PATH}/99-gfwlist-noipv6.conf"
-			fi
-			fwd_dns="${TUN_DNS}"
-			[ -n "$CHINADNS_DNS" ] && unset fwd_dns
-			[ -n "${REMOTE_FAKEDNS}" ] && unset ipset_flag
-			sort -u "${TMP_PATH}/gfwlist" | gen_items ipsets="${ipset_flag}" dnss="${fwd_dns}" outf="${TMP_DNSMASQ_PATH}/99-gfwlist.conf" ipsetoutf="${TMP_DNSMASQ_PATH}/ipset.conf"
-			echolog "  - [$?]防火墙域名表(gfwlist)：${fwd_dns:-默认}"
-			rm -f "${TMP_PATH}/gfwlist"
-		}
-		
-		# 中国列表以外 模式
-		[ -n "${CHINADNS_DNS}" ] && {
-			fwd_dns="${LOCAL_DNS}"
-			[ -n "$CHINADNS_DNS" ] && unset fwd_dns
-			[ -s "${RULES_PATH}/chnlist" ] && {
-				grep -v -E "$count_hosts_str" "${RULES_PATH}/chnlist" | gen_items ipsets="chnroute,chnroute6" dnss="${fwd_dns}" outf="${TMP_DNSMASQ_PATH}/19-chinalist_host.conf" ipsetoutf="${TMP_DNSMASQ_PATH}/ipset.conf"
-				echolog "  - [$?]中国域名表(chnroute)：${fwd_dns:-默认}"
+			# 中国列表以外 模式
+			[ -n "${CHINADNS_DNS}" ] && {
+				fwd_dns="${LOCAL_DNS}"
+				[ -n "$CHINADNS_DNS" ] && unset fwd_dns
+				[ -s "${RULES_PATH}/chnlist" ] && {
+					grep -v -E "$count_hosts_str" "${RULES_PATH}/chnlist" | gen_items ipsets="chnroute,chnroute6" dnss="${fwd_dns}" outf="${TMP_DNSMASQ_PATH}/19-chinalist_host.conf" ipsetoutf="${TMP_DNSMASQ_PATH}/ipset.conf"
+					echolog "  - [$?]中国域名表(chnroute)：${fwd_dns:-默认}"
+				}
 			}
-		}
-	else
-		#回国模式
-		[ -s "${RULES_PATH}/chnlist" ] && {
-			grep -v -E "$count_hosts_str" "${RULES_PATH}/chnlist" > "${TMP_PATH}/chnlist"
-			
-			local ipset_flag="chnroute,chnroute6"
-			if [ "${NO_PROXY_IPV6}" = "1" ]; then
-				ipset_flag="chnroute"
-				sort -u "${TMP_PATH}/chnlist" | gen_address_items address="::" outf="${TMP_DNSMASQ_PATH}/99-chinalist_host-noipv6.conf"
-			fi
-			fwd_dns="${TUN_DNS}"
-			[ -n "${REMOTE_FAKEDNS}" ] && unset ipset_flag
-			sort -u "${TMP_PATH}/chnlist" | gen_items ipsets="${ipset_flag}" dnss="${fwd_dns}" outf="${TMP_DNSMASQ_PATH}/99-chinalist_host.conf" ipsetoutf="${TMP_DNSMASQ_PATH}/ipset.conf"
-			echolog "  - [$?]中国域名表(chnroute)：${fwd_dns:-默认}"
-			rm -f "${TMP_PATH}/chnlist"
-		}
+		else
+			#回国模式
+			[ -s "${RULES_PATH}/chnlist" ] && {
+				grep -v -E "$count_hosts_str" "${RULES_PATH}/chnlist" > "${TMP_PATH}/chnlist"
+
+				local ipset_flag="chnroute,chnroute6"
+				if [ "${NO_PROXY_IPV6}" = "1" ]; then
+					ipset_flag="chnroute"
+					sort -u "${TMP_PATH}/chnlist" | gen_address_items address="::" outf="${TMP_DNSMASQ_PATH}/99-chinalist_host-noipv6.conf"
+				fi
+				fwd_dns="${TUN_DNS}"
+				[ -n "${REMOTE_FAKEDNS}" ] && unset ipset_flag
+				sort -u "${TMP_PATH}/chnlist" | gen_items ipsets="${ipset_flag}" dnss="${fwd_dns}" outf="${TMP_DNSMASQ_PATH}/99-chinalist_host.conf" ipsetoutf="${TMP_DNSMASQ_PATH}/ipset.conf"
+				echolog "  - [$?]中国域名表(chnroute)：${fwd_dns:-默认}"
+				rm -f "${TMP_PATH}/chnlist"
+			}
+		fi
+
+		ipset_merge ${TMP_DNSMASQ_PATH}
 	fi
-	
-	ipset_merge ${TMP_DNSMASQ_PATH}
 	
 	echo "conf-dir=${TMP_DNSMASQ_PATH}" > $DNSMASQ_CONF_FILE
 	[ -n "${CHINADNS_DNS}" ] && {


### PR DESCRIPTION
重新添加‘DNS 不过滤’选项，适合自己分流DNS的玩家(如: MosDNS)