### PR TITLE
add googletranslate to direct_host

### DIFF
--- a/luci-app-passwall/root/usr/share/passwall/rules/direct_host
+++ b/luci-app-passwall/root/usr/share/passwall/rules/direct_host
@@ -16,3 +16,7 @@ cdn-ws.content.steamchina.com
 cdn-qc.content.steamchina.com
 cdn-ali.content.steamchina.com
 epicgames-download1-1251447533.file.myqcloud.com
+
+#googletranslate
+translate.googleapis.com
+translate.google.com


### PR DESCRIPTION
谷歌翻译在国内有服务器。
我自己没有将局域网的客户端都代理，不加这一条会导致没有被代理的设备无法使用Chrome原生的网页翻译，并且反应速度尚可，大佬看一眼~~~