### PR TITLE
luci: add port 8080 to common use TCP ports

### DIFF
--- a/luci-app-passwall/luasrc/model/cbi/passwall/client/other.lua
+++ b/luci-app-passwall/luasrc/model/cbi/passwall/client/other.lua
@@ -82,9 +82,9 @@ o:value("80,443", translate("QUIC"))
 
 ---- TCP Redir Ports
 o = s:option(Value, "tcp_redir_ports", translate("TCP Redir Ports"))
-o.default = "22,25,53,143,465,587,853,993,995,80,443"
+o.default = "22,25,53,143,465,587,853,993,995,80,443,8080"
 o:value("1:65535", translate("All"))
-o:value("22,25,53,143,465,587,853,993,995,80,443", translate("Common Use"))
+o:value("22,25,53,143,465,587,853,993,995,80,443,8080", translate("Common Use"))
 o:value("80,443", translate("Only Web"))
 o:value("80:65535", "80 " .. translate("or more"))
 o:value("1:443", "443 " .. translate("or less"))

--- a/luci-app-passwall/root/usr/share/passwall/0_default_config
+++ b/luci-app-passwall/root/usr/share/passwall/0_default_config
@@ -30,7 +30,7 @@ config global_forwarding
 	option udp_no_redir_ports '53'
 	option tcp_proxy_drop_ports 'disable'
 	option udp_proxy_drop_ports '80,443'
-	option tcp_redir_ports '22,25,53,143,465,587,853,993,995,80,443'
+	option tcp_redir_ports '22,25,53,143,465,587,853,993,995,80,443,8080'
 	option udp_redir_ports '1:65535'
 	option accept_icmp '0'
 	option tcp_proxy_way 'redirect'


### PR DESCRIPTION
Port 8080 is used by speedtest.net