### PR TITLE
support bufferSize for xray

### DIFF
--- a/luci-app-passwall/Makefile
+++ b/luci-app-passwall/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=luci-app-passwall
 PKG_VERSION:=4.53
-PKG_RELEASE:=6
+PKG_RELEASE:=7
 
 PKG_CONFIG_DEPENDS:= \
 	CONFIG_PACKAGE_$(PKG_NAME)_Transparent_Proxy \

--- a/luci-app-passwall/luasrc/model/cbi/passwall/api/gen_v2ray.lua
+++ b/luci-app-passwall/luasrc/model/cbi/passwall/api/gen_v2ray.lua
@@ -9,6 +9,7 @@ local tcp_redir_port = var["-tcp_redir_port"]
 local udp_redir_port = var["-udp_redir_port"]
 local sniffing = var["-sniffing"]
 local route_only = var["-route_only"]
+local buffer_size = var["-buffer_size"]
 local local_socks_address = var["-local_socks_address"] or "0.0.0.0"
 local local_socks_port = var["-local_socks_port"]
 local local_socks_username = var["-local_socks_username"]
@@ -685,25 +686,23 @@ if inbounds or outbounds then
         -- 路由
         routing = routing,
         -- 本地策略
-        --[[
         policy = {
             levels = {
                 [0] = {
-                    handshake = 4,
-                    connIdle = 300,
-                    uplinkOnly = 2,
-                    downlinkOnly = 5,
-                    bufferSize = 10240,
+                    -- handshake = 4,
+                    -- connIdle = 300,
+                    -- uplinkOnly = 2,
+                    -- downlinkOnly = 5,
+                    bufferSize = buffer_size and tonumber(buffer_size) or nil,
                     statsUserUplink = false,
                     statsUserDownlink = false
                 }
             },
-            system = {
-                statsInboundUplink = false,
-                statsInboundDownlink = false
-            }
+            -- system = {
+            --     statsInboundUplink = false,
+            --     statsInboundDownlink = false
+            -- }
         }
-        ]]--
     }
     print(jsonc.stringify(config, 1))
 end

--- a/luci-app-passwall/luasrc/model/cbi/passwall/client/other.lua
+++ b/luci-app-passwall/luasrc/model/cbi/passwall/client/other.lua
@@ -136,6 +136,10 @@ o = s:option(Flag, "route_only", translate("Sniffing Route Only (Xray)"), transl
 o.default = 0
 o:depends("sniffing", true)
 
+o = s:option(Value, "buffer_size", translate("Buffer Size (Xray)"), translate("Buffer size for every connection (kB)"))
+o.rmempty = true
+o.datatype = "uinteger"
+
 local domains_excluded = string.format("/usr/share/%s/rules/domains_excluded", appname)
 o = s:option(TextValue, "no_sniffing_hosts", translate("No Sniffing Lists"), translate("Hosts added into No Sniffing Lists will not resolve again on server (Xray only)."))
 o.rows = 15

--- a/luci-app-passwall/po/zh-cn/passwall.po
+++ b/luci-app-passwall/po/zh-cn/passwall.po
@@ -1377,3 +1377,9 @@ msgstr "不进行流量嗅探的域名列表"
 
 msgid "Hosts added into No Sniffing Lists will not resolve again on server (Xray only)."
 msgstr "加入的域名不会再次在服务器解析（仅适用于Xray）。"
+
+msgid "Buffer Size (Xray)"
+msgstr "缓冲区大小"
+
+msgid "Buffer size for every connection (kB)"
+msgstr "每一个连接的缓冲区大小（kB）"

--- a/luci-app-passwall/root/usr/share/passwall/app.sh
+++ b/luci-app-passwall/root/usr/share/passwall/app.sh
@@ -330,6 +330,8 @@ run_v2ray() {
 		local route_only=$(config_t_get global_forwarding route_only 0)
 		[ "${route_only}" = "1" ] && _extra_param="${_extra_param} -route_only 1"
 	}
+	local buffer_size=$(config_t_get global_forwarding buffer_size)
+	[ -n "${buffer_size}" ] && _extra_param="${_extra_param} -buffer_size ${buffer_size}"
 	case "$dns_proto" in
 		tcp)
 			local _dns_forward=$(get_first_dns dns_tcp_server 53 | sed 's/#/:/g')


### PR DESCRIPTION
增加设置xray的bufferSize。
设置xray连接的bufferSize对某些设备有非常大影响，
例如rtd1296（4核a53，1.4GHz），4GB内存，协议vmess-tls-tcp
* 不设置bufferSize：平均 334 Mbits/sec
* 设置bufferSize为512: 平均 583 Mbits/sec
