### PR TITLE
Readd -pthread to ipt2socks compile options

### DIFF
--- a/ipt2socks/Makefile
+++ b/ipt2socks/Makefile
@@ -31,7 +31,7 @@ define Package/ipt2socks/description
   Utility for converting iptables (redirect/tproxy) to socks5.
 endef
 
-TARGET_CFLAGS+= $(FPIC) -flto
+TARGET_CFLAGS+= $(FPIC) -flto -pthread
 MAKE_FLAGS+= \
 	CFLAGS="-std=c99 $(TARGET_CFLAGS)" \
 	EVCFLAGS="$(TARGET_CFLAGS)"


### PR DESCRIPTION
Fix linker error for arc_archs and arc_arc700:

2022-05-26T02:00:59.1207911Z /home/build/openwrt/staging_dir/toolchain-arc_archs_gcc-8.4.0_glibc/bin/../lib/gcc/arc-openwrt-linux-gnu/8.4.0/../../../../arc-openwrt-linux-gnu/bin/ld: /home/build/openwrt/tmp/ccUGK6zX.ltrans0.ltrans.o: in function `main':
2022-05-26T02:00:59.1208788Z <artificial>:(.text.startup+0xee8): undefined reference to `pthread_create'
2022-05-26T02:00:59.1209619Z /home/build/openwrt/staging_dir/toolchain-arc_archs_gcc-8.4.0_glibc/bin/../lib/gcc/arc-openwrt-linux-gnu/8.4.0/../../../../arc-openwrt-linux-gnu/bin/ld: <artificial>:(.text.startup+0xee8): undefined reference to `pthread_create'
2022-05-26T02:00:59.1210305Z collect2: error: ld returned 1 exit status
2022-05-26T02:00:59.1214282Z make[4]: *** [Makefile:25: ipt2socks] Error 1