### PR TITLE
luci: cleanup makefile

### DIFF
--- a/luci-app-passwall/Makefile
+++ b/luci-app-passwall/Makefile
@@ -38,7 +38,7 @@ LUCI_DEPENDS:=+coreutils +coreutils-base64 +coreutils-nohup +curl \
 	+microsocks +resolveip +tcping +unzip
 
 define Package/$(PKG_NAME)/config
-	if Package/$(PKG_NAME)
+	if Package_$(PKG_NAME)
 		menu "PassWall Configuration"
 			config PACKAGE_$(PKG_NAME)_Iptables_Transparent_Proxy
 				bool "Iptables Transparent Proxy"

--- a/luci-app-passwall/Makefile
+++ b/luci-app-passwall/Makefile
@@ -38,7 +38,7 @@ LUCI_DEPENDS:=+coreutils +coreutils-base64 +coreutils-nohup +curl \
 	+microsocks +resolveip +tcping +unzip
 
 define Package/$(PKG_NAME)/config
-	if Package_$(PKG_NAME)
+	if PACKAGE_$(PKG_NAME)
 		menu "PassWall Configuration"
 			config PACKAGE_$(PKG_NAME)_Iptables_Transparent_Proxy
 				bool "Iptables Transparent Proxy"

--- a/luci-app-passwall/Makefile
+++ b/luci-app-passwall/Makefile
@@ -35,131 +35,131 @@ LUCI_TITLE:=LuCI support for PassWall
 LUCI_PKGARCH:=all
 LUCI_DEPENDS:=+coreutils +coreutils-base64 +coreutils-nohup +curl \
 	+dns2socks +dns2tcp +ip-full +libuci-lua +lua +luci-compat +luci-lib-jsonc \
-	+microsocks +resolveip +tcping +unzip \
-	+PACKAGE_$(PKG_NAME)_INCLUDE_Brook:brook \
-	+PACKAGE_$(PKG_NAME)_INCLUDE_ChinaDNS_NG:chinadns-ng \
-	+PACKAGE_$(PKG_NAME)_INCLUDE_Haproxy:haproxy \
-	+PACKAGE_$(PKG_NAME)_INCLUDE_Hysteria:hysteria \
-	+PACKAGE_$(PKG_NAME)_INCLUDE_NaiveProxy:naiveproxy \
-	+PACKAGE_$(PKG_NAME)_INCLUDE_Shadowsocks_Libev_Client:shadowsocks-libev-ss-local \
-	+PACKAGE_$(PKG_NAME)_INCLUDE_Shadowsocks_Libev_Client:shadowsocks-libev-ss-redir \
-	+PACKAGE_$(PKG_NAME)_INCLUDE_Shadowsocks_Libev_Server:shadowsocks-libev-ss-server \
-	+PACKAGE_$(PKG_NAME)_INCLUDE_Shadowsocks_Rust_Client:shadowsocks-rust-sslocal \
-	+PACKAGE_$(PKG_NAME)_INCLUDE_Shadowsocks_Rust_Server:shadowsocks-rust-ssserver \
-	+PACKAGE_$(PKG_NAME)_INCLUDE_ShadowsocksR_Libev_Client:shadowsocksr-libev-ssr-local \
-	+PACKAGE_$(PKG_NAME)_INCLUDE_ShadowsocksR_Libev_Client:shadowsocksr-libev-ssr-redir \
-	+PACKAGE_$(PKG_NAME)_INCLUDE_ShadowsocksR_Libev_Server:shadowsocksr-libev-ssr-server \
-	+PACKAGE_$(PKG_NAME)_INCLUDE_Simple_Obfs:simple-obfs \
-	+PACKAGE_$(PKG_NAME)_INCLUDE_Trojan_GO:trojan-go \
-	+PACKAGE_$(PKG_NAME)_INCLUDE_Trojan_Plus:trojan-plus \
-	+PACKAGE_$(PKG_NAME)_INCLUDE_V2ray:v2ray-core \
-	+PACKAGE_$(PKG_NAME)_INCLUDE_V2ray_Plugin:v2ray-plugin \
-	+PACKAGE_$(PKG_NAME)_INCLUDE_Xray:xray-core \
-	+PACKAGE_$(PKG_NAME)_INCLUDE_Xray_Plugin:xray-plugin
+	+microsocks +resolveip +tcping +unzip
 
 define Package/$(PKG_NAME)/config
-menu "Configuration"
+	if Package/$(PKG_NAME)
+		menu "PassWall Configuration"
+			config PACKAGE_$(PKG_NAME)_Iptables_Transparent_Proxy
+				bool "Iptables Transparent Proxy"
+				select PACKAGE_dnsmasq-full
+				select PACKAGE_ipset
+				select PACKAGE_ipt2socks
+				select PACKAGE_iptables
+				select PACKAGE_iptables-legacy
+				select PACKAGE_iptables-mod-conntrack-extra
+				select PACKAGE_iptables-mod-iprange
+				select PACKAGE_iptables-mod-socket
+				select PACKAGE_iptables-mod-tproxy
+				select PACKAGE_kmod-ipt-nat
+				default y if ! PACKAGE_firewall4
 
-config PACKAGE_$(PKG_NAME)_Iptables_Transparent_Proxy
-	bool "Iptables Transparent Proxy"
-	select PACKAGE_dnsmasq-full
-	select PACKAGE_ipset
-	select PACKAGE_ipt2socks
-	select PACKAGE_iptables
-	select PACKAGE_iptables-legacy
-	select PACKAGE_iptables-mod-conntrack-extra
-	select PACKAGE_iptables-mod-iprange
-	select PACKAGE_iptables-mod-socket
-	select PACKAGE_iptables-mod-tproxy
-	select PACKAGE_kmod-ipt-nat
-	default y if ! PACKAGE_firewall4
+			config PACKAGE_$(PKG_NAME)_Nftables_Transparent_Proxy
+				bool "Nftables Transparent Proxy"
+				select PACKAGE_dnsmasq-full
+				select PACKAGE_nftables
+				select PACKAGE_kmod-nft-socket
+				select PACKAGE_kmod-nft-tproxy
+				select PACKAGE_kmod-nft-nat
+				default y if PACKAGE_firewall4
 
-config PACKAGE_$(PKG_NAME)_Nftables_Transparent_Proxy
-	bool "Nftables Transparent Proxy"
-	select PACKAGE_dnsmasq-full
-	select PACKAGE_nftables
-	select PACKAGE_kmod-nft-socket
-	select PACKAGE_kmod-nft-tproxy
-	select PACKAGE_kmod-nft-nat
-	default y if PACKAGE_firewall4
+			config PACKAGE_$(PKG_NAME)_INCLUDE_Brook
+				bool "Include Brook"
+				select PACKAGE_brook
+				default n
 
-config PACKAGE_$(PKG_NAME)_INCLUDE_Brook
-	bool "Include Brook"
-	default n
+			config PACKAGE_$(PKG_NAME)_INCLUDE_ChinaDNS_NG
+				bool "Include ChinaDNS-NG"
+				select PACKAGE_ipset
+				select PACKAGE_chinadns-ng
+				default n
 
-config PACKAGE_$(PKG_NAME)_INCLUDE_ChinaDNS_NG
-	bool "Include ChinaDNS-NG"
-	select PACKAGE_ipset
-	default n
+			config PACKAGE_$(PKG_NAME)_INCLUDE_Haproxy
+				bool "Include Haproxy"
+				select PACKAGE_haproxy
+				default y if aarch64||arm||i386||x86_64
 
-config PACKAGE_$(PKG_NAME)_INCLUDE_Haproxy
-	bool "Include Haproxy"
-	default y if aarch64||arm||i386||x86_64
+			config PACKAGE_$(PKG_NAME)_INCLUDE_Hysteria
+				bool "Include Hysteria"
+				select PACKAGE_hysteria
+				default n
 
-config PACKAGE_$(PKG_NAME)_INCLUDE_Hysteria
-	bool "Include Hysteria"
-	default n
+			config PACKAGE_$(PKG_NAME)_INCLUDE_NaiveProxy
+				bool "Include NaiveProxy"
+				depends on !(arc||(arm&&TARGET_gemini)||armeb||mips||mips64||powerpc)
+				select PACKAGE_naiveproxy
+				default n
 
-config PACKAGE_$(PKG_NAME)_INCLUDE_NaiveProxy
-	bool "Include NaiveProxy"
-	depends on !(arc||(arm&&TARGET_gemini)||armeb||mips||mips64||powerpc)
-	default n
+			config PACKAGE_$(PKG_NAME)_INCLUDE_Shadowsocks_Libev_Client
+				bool "Include Shadowsocks Libev Client"
+				select PACKAGE_shadowsocks-libev-ss-local
+				select PACKAGE_shadowsocks-libev-ss-redir
+				default y
 
-config PACKAGE_$(PKG_NAME)_INCLUDE_Shadowsocks_Libev_Client
-	bool "Include Shadowsocks Libev Client"
-	default y
+			config PACKAGE_$(PKG_NAME)_INCLUDE_Shadowsocks_Libev_Server
+				bool "Include Shadowsocks Libev Server"
+				select PACKAGE_shadowsocks-libev-ss-server
+				default y if aarch64||arm||i386||x86_64
 
-config PACKAGE_$(PKG_NAME)_INCLUDE_Shadowsocks_Libev_Server
-	bool "Include Shadowsocks Libev Server"
-	default y if aarch64||arm||i386||x86_64
+			config PACKAGE_$(PKG_NAME)_INCLUDE_Shadowsocks_Rust_Client
+				bool "Include Shadowsocks Rust Client"
+				depends on aarch64||arm||i386||mips||mipsel||x86_64
+				select PACKAGE_shadowsocks-rust-sslocal
+				default y if aarch64
 
-config PACKAGE_$(PKG_NAME)_INCLUDE_Shadowsocks_Rust_Client
-	bool "Include Shadowsocks Rust Client"
-	depends on aarch64||arm||i386||mips||mipsel||x86_64
-	default y if aarch64
+			config PACKAGE_$(PKG_NAME)_INCLUDE_Shadowsocks_Rust_Server
+				bool "Include Shadowsocks Rust Server"
+				depends on aarch64||arm||i386||mips||mipsel||x86_64
+				select PACKAGE_shadowsocks-rust-ssserver
+				default n
 
-config PACKAGE_$(PKG_NAME)_INCLUDE_Shadowsocks_Rust_Server
-	bool "Include Shadowsocks Rust Server"
-	depends on aarch64||arm||i386||mips||mipsel||x86_64
-	default n
+			config PACKAGE_$(PKG_NAME)_INCLUDE_ShadowsocksR_Libev_Client
+				bool "Include ShadowsocksR Libev Client"
+				select PACKAGE_shadowsocksr-libev-ssr-local
+				select PACKAGE_shadowsocksr-libev-ssr-redir
+				default y
 
-config PACKAGE_$(PKG_NAME)_INCLUDE_ShadowsocksR_Libev_Client
-	bool "Include ShadowsocksR Libev Client"
-	default y
+			config PACKAGE_$(PKG_NAME)_INCLUDE_ShadowsocksR_Libev_Server
+				bool "Include ShadowsocksR Libev Server"
+				select PACKAGE_shadowsocksr-libev-ssr-server
+				default n
 
-config PACKAGE_$(PKG_NAME)_INCLUDE_ShadowsocksR_Libev_Server
-	bool "Include ShadowsocksR Libev Server"
-	default n
+			config PACKAGE_$(PKG_NAME)_INCLUDE_Simple_Obfs
+				bool "Include Simple-Obfs (Shadowsocks Plugin)"
+				select PACKAGE_simple-obfs
+				default y
 
-config PACKAGE_$(PKG_NAME)_INCLUDE_Simple_Obfs
-	bool "Include Simple-Obfs (Shadowsocks Plugin)"
-	default y
+			config PACKAGE_$(PKG_NAME)_INCLUDE_Trojan_GO
+				bool "Include Trojan-GO"
+				select PACKAGE_trojan-go
+				default n
 
-config PACKAGE_$(PKG_NAME)_INCLUDE_Trojan_GO
-	bool "Include Trojan-GO"
-	default n
+			config PACKAGE_$(PKG_NAME)_INCLUDE_Trojan_Plus
+				bool "Include Trojan-Plus"
+				select PACKAGE_trojan-plus
+				default y
 
-config PACKAGE_$(PKG_NAME)_INCLUDE_Trojan_Plus
-	bool "Include Trojan-Plus"
-	default y
+			config PACKAGE_$(PKG_NAME)_INCLUDE_V2ray
+				bool "Include V2ray"
+				select PACKAGE_v2ray-core
+				default y if aarch64||arm||i386||x86_64
 
-config PACKAGE_$(PKG_NAME)_INCLUDE_V2ray
-	bool "Include V2ray"
-	default y if aarch64||arm||i386||x86_64
+			config PACKAGE_$(PKG_NAME)_INCLUDE_V2ray_Plugin
+				bool "Include V2ray-Plugin (Shadowsocks Plugin)"
+				select PACKAGE_v2ray-plugin
+				default y if aarch64||arm||i386||x86_64
 
-config PACKAGE_$(PKG_NAME)_INCLUDE_V2ray_Plugin
-	bool "Include V2ray-Plugin (Shadowsocks Plugin)"
-	default y if aarch64||arm||i386||x86_64
+			config PACKAGE_$(PKG_NAME)_INCLUDE_Xray
+				bool "Include Xray"
+				select PACKAGE_xray-core
+				default y if aarch64||arm||i386||x86_64
 
-config PACKAGE_$(PKG_NAME)_INCLUDE_Xray
-	bool "Include Xray"
-	default y if aarch64||arm||i386||x86_64
-
-config PACKAGE_$(PKG_NAME)_INCLUDE_Xray_Plugin
-	bool "Include Xray-Plugin (Shadowsocks Plugin)"
-	default n
-
-endmenu
+			config PACKAGE_$(PKG_NAME)_INCLUDE_Xray_Plugin
+				bool "Include Xray-Plugin (Shadowsocks Plugin)"
+				select PACKAGE_xray-plugin
+				default n
+		endmenu
+	endif
 endef
 
 define Package/$(PKG_NAME)/conffiles


### PR DESCRIPTION
使`luci-app-passwall-INCLUDE_xxx`类包只有在luci-app-passwall被选中后才能被配置，不选择luci-app-passwall则不会被默认安装，选中luci-app-passwall后仍能默认安装trojan-go, xray-core等组件。

其他影响：因trojan-go, xray-core等组件不再是luci-app-passwall的依赖，若直接移除此类组件不会导致luci-app-passwall被移除。

Relates to #2107