### PR TITLE
luci: fix dnsmasq restart order

### DIFF
--- a/luci-app-passwall/root/usr/share/passwall/helper_dnsmasq.sh
+++ b/luci-app-passwall/root/usr/share/passwall/helper_dnsmasq.sh
@@ -45,8 +45,8 @@ logic_restart() {
 		for server in $(uci -q get dhcp.@dnsmasq[0].server); do
 			[ -n "$(echo $server | grep '\/')" ] || uci -q del_list dhcp.@dnsmasq[0].server="$server" 
 		done
-		/etc/init.d/dnsmasq restart >/dev/null 2>&1
 		restore_servers
+		/etc/init.d/dnsmasq restart >/dev/null 2>&1
 	else
 		/etc/init.d/dnsmasq restart >/dev/null 2>&1
 	fi


### PR DESCRIPTION
L大5.15内核，每次passwall应用设置之后，客户端DNS解析失败，nslookup报REFUSED错误，手工重启dnsmasq服务才能恢复正常。开启dnsmasq查询日志，看到大量`config error is REFUSED`错误

调整`helper_dnsmasq.sh`中dnsmasq重启部分的代码顺序，问题解决