### PR TITLE
Revert "luci: fix dnsmasq restart order"

### DIFF
--- a/luci-app-passwall/root/usr/share/passwall/helper_dnsmasq.sh
+++ b/luci-app-passwall/root/usr/share/passwall/helper_dnsmasq.sh
@@ -45,8 +45,8 @@ logic_restart() {
 		for server in $(uci -q get dhcp.@dnsmasq[0].server); do
 			[ -n "$(echo $server | grep '\/')" ] || uci -q del_list dhcp.@dnsmasq[0].server="$server" 
 		done
-		restore_servers
 		/etc/init.d/dnsmasq restart >/dev/null 2>&1
+		restore_servers
 	else
 		/etc/init.d/dnsmasq restart >/dev/null 2>&1
 	fi


### PR DESCRIPTION
Reverts xiaorouji/openwrt-passwall#2153

经多次编译不同版本测试，确认此修改会导致开启 ChinaDNS-NG 后，客户端无法获取到正确的无污染 IP（常规 SS 节点，非 Xray 节点或 Xray 分流节点），建议先还原此修改。

具体表现：开启 ChinaDNS-NG 后，最终返回客户端的 IP 来自于国内 DNS，而不是可信 DNS，是被污染的 IP。