### PR TITLE
change the default value of VLESS subscribe fingerprint to chrome

### DIFF
--- a/luci-app-passwall/root/usr/share/passwall/subscribe.lua
+++ b/luci-app-passwall/root/usr/share/passwall/subscribe.lua
@@ -775,7 +775,7 @@ local function processData(szType, content, add_mode, add_from)
 				result.tls = "1"
 				result.tlsflow = params.flow or nil
 				result.tls_serverName = (params.sni and params.sni ~= "") and params.sni or params.host
-				result.fingerprint = (params.fp and params.fp ~= "") and params.fp or nil
+				result.fingerprint = (params.fp and params.fp ~= "") and params.fp or "chrome"
 			end
 
 			result.port = port


### PR DESCRIPTION
According to section 4.4.0 in https://github.com/XTLS/Xray-core/discussions/716, the default value of fp in VLESS share link should be chrome when omitted.