### PR TITLE
Add International Xiaomi Community to Proxy Host

### DIFF
--- a/luci-app-passwall/root/usr/share/passwall/rules/proxy_host
+++ b/luci-app-passwall/root/usr/share/passwall/rules/proxy_host
@@ -1,4 +1,5 @@
 bing.com
+c.mi.com
 sspanel.net
 v2ex.com
 


### PR DESCRIPTION
The international Xiaomi community blocks access to mainland China, and the domestic DNS resolution results in NXDOMAIN.

You can view it at this link.
https://ping.chinaz.com/c.mi.com
Or.
https://ping.chinaz.com/new.c.mi.com

c.mi.com is a subdomain dedicated to Xiaomi's international business, so only c.mi.com needs to be added so that it will not affect mi.com requests.