### PR TITLE
luci: add balancer support in shunt mode

### DIFF
--- a/luci-app-passwall/luasrc/model/cbi/passwall/client/app_update.lua
+++ b/luci-app-passwall/luasrc/model/cbi/passwall/client/app_update.lua
@@ -15,7 +15,7 @@ local k, v
 local com = require "luci.passwall.com"
 for k, v in pairs(com) do
 	o = s:option(Value, k:gsub("%-","_") .. "_file", translatef("%s App Path", v.name))
-	o.default = v.default_path or ("/usr/bin/"..k)
+	o.default = v.default_path or ("/usr/bin/" .. k)
 	o.rmempty = false
 end
 

--- a/luci-app-passwall/luasrc/model/cbi/passwall/client/auto_switch.lua
+++ b/luci-app-passwall/luasrc/model/cbi/passwall/client/auto_switch.lua
@@ -59,7 +59,7 @@ o = s:option(Flag, "restore_switch", "TCP " .. translate("Restore Switch"), tran
 o = s:option(ListValue, "shunt_logic", "TCP " .. translate("If the main node is V2ray/Xray shunt"))
 o:value("0", translate("Switch it"))
 o:value("1", translate("Applying to the default node"))
-o:value("2", translate("Applying to the default preproxy node"))
+o:value("2", translate("Applying to the preproxy node"))
 
 m:append(Template(appname .. "/auto_switch/footer"))
 

--- a/luci-app-passwall/luasrc/model/cbi/passwall/client/global.lua
+++ b/luci-app-passwall/luasrc/model/cbi/passwall/client/global.lua
@@ -105,63 +105,85 @@ if (has_v2ray or has_xray) and #nodes_table > 0 then
 	local normal_list = {}
 	local shunt_list = {}
 	for k, v in pairs(nodes_table) do
-		if v.node_type == "normal" then
+		if v.node_type == "normal" or v.protocol == "_balancing" then
 			normal_list[#normal_list + 1] = v
 		end
 		if v.protocol and v.protocol == "_shunt" then
 			shunt_list[#shunt_list + 1] = v
 		end
 	end
+	
+	local function get_cfgvalue(shunt_node_id, rule_id)
+		return function(self, section)
+			return m:get(shunt_node_id, rule_id) or "nil"
+		end
+	end
+	local function get_write(shunt_node_id, rule_id)
+		return function(self, section, value)
+			m:set(shunt_node_id, rule_id, value)
+		end
+	end
+
 	for k, v in pairs(shunt_list) do
+		local vid = v.id:sub(1, 8)
+		o = s:taboption("Main", ListValue, vid .. "-main_node", string.format('<a style="color:red">%s</a>', translate("Preproxy Node")), translate("Set the node to be used as a pre-proxy. Each rule (including <code>Default</code>) has a separate switch that controls whether this rule uses the pre-proxy or not."))
+		o:depends("tcp_node", v.id)
+		o:value("nil", translate("Close"))
+		for k1, v1 in pairs(normal_list) do
+			o:value(v1.id, v1.remark)
+		end
+		o.cfgvalue = get_cfgvalue(v.id, "main_node")
+		o.write = get_write(v.id, "main_node")
+
 		uci:foreach(appname, "shunt_rules", function(e)
 			local id = e[".name"]
+			local node_option = vid .. "-" .. id .. "_node"
 			if id and e.remarks then
-				o = s:taboption("Main", ListValue, v.id .. "." .. id .. "_node", string.format('* <a href="%s" target="_blank">%s</a>', api.url("shunt_rules", id), e.remarks))
+				o = s:taboption("Main", ListValue, node_option, string.format('* <a href="%s" target="_blank">%s</a>', api.url("shunt_rules", id), e.remarks))
 				o:depends("tcp_node", v.id)
 				o:value("nil", translate("Close"))
 				o:value("_default", translate("Default"))
 				o:value("_direct", translate("Direct Connection"))
 				o:value("_blackhole", translate("Blackhole"))
+				local pt = s:taboption("Main", ListValue, vid .. "-".. id .. "_proxy_tag", string.format('* <a style="color:red">%s</a>', e.remarks .. " " .. translate("Preproxy")))
+				pt:value("nil", translate("Close"))
+				pt:value("main", translate("Preproxy Node"))
+				pt.default = "nil"
 				for k1, v1 in pairs(normal_list) do
-					o:value(v1.id, v1["remark"])
+					o:value(v1.id, v1.remark)
+					if v1.protocol ~= "_balancing" then
+						pt:depends(node_option, v1.id)
+					end
 				end
-				o.cfgvalue = function(self, section)
-					return m:get(v.id, id) or "nil"
-				end
-				o.write = function(self, section, value)
-					m:set(v.id, id, value)
-				end
+				o.cfgvalue = get_cfgvalue(v.id, id)
+				o.write = get_write(v.id, id)
+				pt.cfgvalue = get_cfgvalue(v.id, id .. "_proxy_tag")
+				pt.write = get_write(v.id, id .. "_proxy_tag")
 			end
 		end)
 
 		local id = "default_node"
-		o = s:taboption("Main", ListValue, v.id .. "." .. id, string.format('* <a style="color:red">%s</a>', translate("Default")))
+		o = s:taboption("Main", ListValue, vid .. "-" .. id, string.format('* <a style="color:red">%s</a>', translate("Default")))
 		o:depends("tcp_node", v.id)
 		o:value("_direct", translate("Direct Connection"))
 		o:value("_blackhole", translate("Blackhole"))
 		for k1, v1 in pairs(normal_list) do
 			o:value(v1.id, v1["remark"])
 		end
-		o.cfgvalue = function(self, section)
-			return m:get(v.id, id) or "nil"
-		end
-		o.write = function(self, section, value)
-			m:set(v.id, id, value)
-		end
+		o.cfgvalue = get_cfgvalue(v.id, id)
+		o.write = get_write(v.id, id)
 
-		local id = "main_node"
-		o = s:taboption("Main", ListValue, v.id .. "." .. id, string.format('* <a style="color:red">%s</a>', translate("Default Preproxy")), translate("When using, localhost will connect this node first and then use this node to connect the default node."))
-		o:depends("tcp_node", v.id)
-		o:value("nil", translate("Close"))
+		local id = "default_proxy_tag"
+		o = s:taboption("Main", ListValue, vid .. "-" .. id, string.format('* <a style="color:red">%s</a>', translate("Default Preproxy")), translate("When using, localhost will connect this node first and then use this node to connect the default node."))
 		for k1, v1 in pairs(normal_list) do
-			o:value(v1.id, v1["remark"])
+			if v1.protocol ~= "_balancing" then
+				o:depends(vid .. "-default_node", v1.id)
+			end
 		end
-		o.cfgvalue = function(self, section)
-			return m:get(v.id, id) or "nil"
-		end
-		o.write = function(self, section, value)
-			m:set(v.id, id, value)
-		end
+		o:value("nil", translate("Close"))
+		o:value("main", translate("Preproxy Node"))
+		o.cfgvalue = get_cfgvalue(v.id, id)
+		o.write = get_write(v.id, id)
 	end
 end
 

--- a/luci-app-passwall/luasrc/model/cbi/passwall/client/node_config.lua
+++ b/luci-app-passwall/luasrc/model/cbi/passwall/client/node_config.lua
@@ -46,7 +46,7 @@ local x_ss_encrypt_method_list = {
 	"aes-128-gcm", "aes-256-gcm", "chacha20-poly1305", "xchacha20-poly1305", "2022-blake3-aes-128-gcm", "2022-blake3-aes-256-gcm", "2022-blake3-chacha20-poly1305"
 }
 
-local security_list = {"none", "auto", "aes-128-gcm", "chacha20-poly1305", "zero"}
+local security_list = { "none", "auto", "aes-128-gcm", "chacha20-poly1305", "zero" }
 
 local header_type_list = {
 	"none", "srtp", "utp", "wechat-video", "dtls", "wireguard"
@@ -133,9 +133,10 @@ iface:depends("protocol", "_iface")
 
 local nodes_table = {}
 for k, e in ipairs(api.get_valid_nodes()) do
-	if e.node_type == "normal" then
+	if e.node_type == "normal" or e.protocol == "_balancing" then
 		nodes_table[#nodes_table + 1] = {
 			id = e[".name"],
+			protocol = e["protocol"],
 			remarks = e["remark"]
 		}
 	end
@@ -145,17 +146,34 @@ end
 local balancing_node = s:option(DynamicList, "balancing_node", translate("Load balancing node list"), translate("Load balancing node list, <a target='_blank' href='https://toutyrater.github.io/routing/balance2.html'>document</a>"))
 for k, v in pairs(nodes_table) do balancing_node:value(v.id, v.remarks) end
 balancing_node:depends("protocol", "_balancing")
+
 local balancingStrategy = s:option(ListValue, "balancingStrategy", translate("Balancing Strategy"))
 balancingStrategy:depends("protocol", "_balancing")
 balancingStrategy:value("random")
 balancingStrategy:value("leastPing")
 balancingStrategy.default = "random"
+-- 探测地址
+local useCustomProbeUrl = s:option(Flag, "useCustomProbeUrl", translate("Use Custome Probe URL"))
+useCustomProbeUrl:depends("balancingStrategy", "leastPing")
+useCustomProbeUrl.description = "By default the built-in probe URL will be used, enable this option to use a custom probe URL."
+local probeUrl = s:option(Value, "probeUrl", translate("Probe URL"))
+probeUrl:depends("useCustomProbeUrl", true)
+probeUrl.default = "https://www.google.com/generate_204"
+probeUrl.description = translate("The URL used to detect the connection status.")
+-- 探测间隔
 local probeInterval = s:option(Value, "probeInterval", translate("Probe Interval"))
 probeInterval:depends("balancingStrategy", "leastPing")
 probeInterval.default = "1m"
 probeInterval.description = translate("The interval between initiating probes. Every time this time elapses, a server status check is performed on a server. The time format is numbers + units, such as '10s', '2h45m', and the supported time units are <code>ns</code>, <code>us</code>, <code>ms</code>, <code>s</code>, <code>m</code>, <code>h</code>, which correspond to nanoseconds, microseconds, milliseconds, seconds, minutes, and hours, respectively.")
 
 -- 分流
+if #nodes_table > 0 then
+	o = s:option(ListValue, "main_node", string.format('<a style="color:red">%s</a>', translate("Preproxy Node")), translate("Set the node to be used as a pre-proxy. Each rule (including <code>Default</code>) has a separate switch that controls whether this rule uses the pre-proxy or not."))
+	o:value("nil", translate("Close"))
+	for k, v in pairs(nodes_table) do
+		o:value(v.id, v.remarks)
+	end
+end
 uci:foreach(appname, "shunt_rules", function(e)
 	if e[".name"] and e.remarks then
 		o = s:option(ListValue, e[".name"], string.format('* <a href="%s" target="_blank">%s</a>', api.url("shunt_rules", e[".name"]), e.remarks))
@@ -166,15 +184,15 @@ uci:foreach(appname, "shunt_rules", function(e)
 		o:depends("protocol", "_shunt")
 
 		if #nodes_table > 0 then
-			_proxy_tag = s:option(ListValue, e[".name"] .. "_proxy_tag", string.format('* <a style="color:red">%s</a>', e.remarks .. " " .. translate("Preproxy")))
-			_proxy_tag:value("nil", translate("Close"))
-			_proxy_tag:value("default", translate("Default"))
-			_proxy_tag:value("main", translate("Default Preproxy"))
-			_proxy_tag.default = "nil"
-
+			local pt = s:option(ListValue, e[".name"] .. "_proxy_tag", string.format('* <a style="color:red">%s</a>', e.remarks .. " " .. translate("Preproxy")))
+			pt:value("nil", translate("Close"))
+			pt:value("main", translate("Preproxy Node"))
+			pt.default = "nil"
 			for k, v in pairs(nodes_table) do
 				o:value(v.id, v.remarks)
-				_proxy_tag:depends(e[".name"], v.id)
+				if v.protocol ~= "_balancing" then
+					pt:depends(e[".name"], v.id)
+				end
 			end
 		end
 	end
@@ -194,16 +212,19 @@ for k, v in pairs(nodes_table) do default_node:value(v.id, v.remarks) end
 default_node:depends("protocol", "_shunt")
 
 if #nodes_table > 0 then
-	o = s:option(ListValue, "main_node", string.format('* <a style="color:red">%s</a>', translate("Default Preproxy")), translate("When using, localhost will connect this node first and then use this node to connect the default node."))
-	o:value("nil", translate("Close"))
+	local dpt = s:option(ListValue, "default_proxy_tag", string.format('* <a style="color:red">%s</a>', translate("Default Preproxy")), translate("When using, localhost will connect this node first and then use this node to connect the default node."))
+	dpt:value("nil", translate("Close"))
+	dpt:value("main", translate("Preproxy Node"))
+	dpt.default = "nil"
 	for k, v in pairs(nodes_table) do
-		o:value(v.id, v.remarks)
-		o:depends("default_node", v.id)
+		if v.protocol ~= "_balancing" then
+			dpt:depends("default_node", v.id)
+		end
 	end
 end
 
 dialerProxy = s:option(Flag, "dialerProxy", translate("dialerProxy"))
-dialerProxy:depends({ type = "Xray", protocol = "_shunt"})
+dialerProxy:depends({ type = "Xray", protocol = "_shunt" })
 
 domainStrategy = s:option(ListValue, "domainStrategy", translate("Domain Strategy"))
 domainStrategy:value("AsIs")
@@ -211,9 +232,9 @@ domainStrategy:value("IPIfNonMatch")
 domainStrategy:value("IPOnDemand")
 domainStrategy.default = "IPOnDemand"
 domainStrategy.description = "<br /><ul><li>" .. translate("'AsIs': Only use domain for routing. Default value.")
-.. "</li><li>" .. translate("'IPIfNonMatch': When no rule matches current domain, resolves it into IP addresses (A or AAAA records) and try all rules again.")
-.. "</li><li>" .. translate("'IPOnDemand': As long as there is a IP-based rule, resolves the domain into IP immediately.")
-.. "</li></ul>"
+	.. "</li><li>" .. translate("'IPIfNonMatch': When no rule matches current domain, resolves it into IP addresses (A or AAAA records) and try all rules again.")
+	.. "</li><li>" .. translate("'IPOnDemand': As long as there is a IP-based rule, resolves the domain into IP immediately.")
+	.. "</li></ul>"
 domainStrategy:depends("protocol", "_shunt")
 
 domainMatcher = s:option(ListValue, "domainMatcher", translate("Domain matcher"))
@@ -808,7 +829,7 @@ h2_path:depends("transport", "h2")
 h2_path:depends("ss_transport", "h2")
 
 h2_health_check = s:option(Flag, "h2_health_check", translate("Health check"))
-h2_health_check:depends({ type = "Xray", transport = "h2"})
+h2_health_check:depends({ type = "Xray", transport = "h2" })
 
 h2_read_idle_timeout = s:option(Value, "h2_read_idle_timeout", translate("Idle timeout"))
 h2_read_idle_timeout.default = "10"
@@ -843,10 +864,10 @@ grpc_serviceName:depends("transport", "grpc")
 grpc_mode = s:option(ListValue, "grpc_mode", "gRPC " .. translate("Transfer mode"))
 grpc_mode:value("gun")
 grpc_mode:value("multi")
-grpc_mode:depends({ type = "Xray", transport = "grpc"})
+grpc_mode:depends({ type = "Xray", transport = "grpc" })
 
 grpc_health_check = s:option(Flag, "grpc_health_check", translate("Health check"))
-grpc_health_check:depends({ type = "Xray", transport = "grpc"})
+grpc_health_check:depends({ type = "Xray", transport = "grpc" })
 
 grpc_idle_timeout = s:option(Value, "grpc_idle_timeout", translate("Idle timeout"))
 grpc_idle_timeout.default = "10"
@@ -862,7 +883,7 @@ grpc_permit_without_stream:depends("grpc_health_check", true)
 
 grpc_initial_windows_size = s:option(Value, "grpc_initial_windows_size", translate("Initial Windows Size"))
 grpc_initial_windows_size.default = "0"
-grpc_initial_windows_size:depends({ type = "Xray", transport = "grpc"})
+grpc_initial_windows_size:depends({ type = "Xray", transport = "grpc" })
 
 -- [[ Trojan-Go Shadowsocks2 ]] --
 ss_aead = s:option(Flag, "ss_aead", translate("Shadowsocks secondary encryption"))

--- a/luci-app-passwall/luasrc/passwall/server_app.lua
+++ b/luci-app-passwall/luasrc/passwall/server_app.lua
@@ -44,14 +44,14 @@ local function ln_run(s, d, command, output)
 	end
 	d = TMP_BIN_PATH .. "/" .. d
 	cmd(string.format('[ ! -f "%s" ] && ln -s %s %s 2>/dev/null', d, s, d))
-	return string.format("%s >%s 2>&1 &", d .. " " ..command, output)
+	return string.format("%s >%s 2>&1 &", d .. " " .. command, output)
 end
 
 local function gen_include()
 	cmd(string.format("echo '#!/bin/sh' > /tmp/etc/%s.include", CONFIG))
 	if nft_flag == "1" then
 		cmd("echo \"\" > " .. CONFIG_PATH .. "/" .. CONFIG .. ".nft")
-		local nft_cmd="for chain in $(nft -a list chains |grep -E \"chain PSW-SERVER\" |awk -F ' ' '{print$2}'); do\n nft list chain inet fw4 ${chain} >> " .. CONFIG_PATH .. "/" .. CONFIG .. ".nft\n done"
+		local nft_cmd = "for chain in $(nft -a list chains |grep -E \"chain PSW-SERVER\" |awk -F ' ' '{print$2}'); do\n nft list chain inet fw4 ${chain} >> " .. CONFIG_PATH .. "/" .. CONFIG .. ".nft\n done"
 		cmd(nft_cmd)
 	end
 	local function extract_rules(n, a)
@@ -215,7 +215,7 @@ local function stop()
 		ip6t("-F PSW-SERVER 2>/dev/null")
 		ip6t("-X PSW-SERVER 2>/dev/null")
 	else
-		nft_cmd="handles=$(nft -a list chain inet fw4 input | grep -E \"PSW-SERVER\" | awk -F '# handle ' '{print$2}')\n for handle in $handles; do\n nft delete rule inet fw4 input handle ${handle} 2>/dev/null\n done"
+		local nft_cmd = "handles=$(nft -a list chain inet fw4 input | grep -E \"PSW-SERVER\" | awk -F '# handle ' '{print$2}')\n for handle in $handles; do\n nft delete rule inet fw4 input handle ${handle} 2>/dev/null\n done"
 		cmd(nft_cmd)
 		cmd("nft flush chain inet fw4 PSW-SERVER 2>/dev/null")
 		cmd("nft delete chain inet fw4 PSW-SERVER 2>/dev/null")

--- a/luci-app-passwall/po/zh-cn/passwall.po
+++ b/luci-app-passwall/po/zh-cn/passwall.po
@@ -352,6 +352,18 @@ msgstr "V2ray 负载均衡"
 msgid "Balancing Strategy"
 msgstr "负载均衡策略"
 
+msgid "Use Custome Probe URL"
+msgstr "使用自定义探测网址"
+
+msgid "By default the built-in probe URL will be used, enable this option to use a custom probe URL."
+msgstr "默认使用内置的探测网址，启用此选项以使用自定义探测网址。"
+
+msgid "Probe URL"
+msgstr "探测网址"
+
+msgid "The URL used to detect the connection status."
+msgstr "用于检测连接状态的网址。"
+
 msgid "Probe Interval"
 msgstr "探测间隔"
 
@@ -369,6 +381,12 @@ msgstr "V2ray 分流"
 
 msgid "Preproxy"
 msgstr "前置代理"
+
+msgid "Preproxy Node"
+msgstr "前置代理节点"
+
+msgid "Set the node to be used as a pre-proxy. Each rule (including <code>Default</code>) has a separate switch that controls whether this rule uses the pre-proxy or not."
+msgstr "设置用作前置代理的节点。每条规则（包括<code>默认</code>）都有独立开关控制本规则是否使用前置代理。"
 
 msgid "Direct Connection"
 msgstr "直连"
@@ -658,8 +676,8 @@ msgstr "切掉它"
 msgid "Applying to the default node"
 msgstr "应用于默认节点"
 
-msgid "Applying to the default preproxy node"
-msgstr "应用于默认前置节点"
+msgid "Applying to the preproxy node"
+msgstr "应用于前置代理节点"
 
 msgid "Add nodes to the standby node list by keywords"
 msgstr "通过关键字添加节点到备用节点列表"


### PR DESCRIPTION
分流模式修改内容：
【Xray负载均衡节点】
- 在分流模式添加对 Xray/V2ray 负载均衡节点的支持。在分流模式中，Xray均衡节点可以设置为默认节点，规则节点，也可以作为前置代理，但是 Xray均衡节点不能应用前置代理。（前置代理为了解锁某些有需要但又被封锁的节点，或者加速连接状况差，延迟高速度慢的节点，是为了提高可用性的，而负载均衡在翻墙场景来说主要也是为了优选节点，同样是提高可用性的。负载均衡作为前置代理可以进一步提升被封节点的可用性，但给负载均衡前面再套一个单节点就失去了负载均衡的意义。）
- 由于之前修改Xray/V2ray负载均衡节点，增加了`leastPing`均衡策略，所以分流模式下如果使用了`leastPing`策略的均衡节点也进行了相应的适配。但因为 Xray/V2ray_v4 目前配置方式的缺陷，每个`leastPing`策略的balancer对节点探测并没有独立的参数控制，甚至对节点发出的探测请求也不是由balancer发出。而是使用一个全局的观测器，可以设置间隔，URL，Xray还可以设置启用并发（V2ray要V5版配置格式才支持），多个balancer都只能直接使用这个观测器观测的结果。所以目前处理方式是，不管是有1个或几个`leastPing`策略的均衡节点，URL，探测间隔使用第一个的设置，对于Xray总是启用并发模式，因为非并发的探测方法在有多个balancer的情况下会表现出很大的问题。
- Xray均衡节点作为前置代理时，如果规则/默认节点是均衡节点其中的一个，则开关无效，前置代理不启用。

【前置代理】
- 原`默认前置代理`，配置项`main_node`改为前置代理总设置，独立于分流规则，对默认规则的`默认前置代理`改为和其他规则一样的`default_proxy_tag`。所有规则（包括默认），如果设置的节点支持使用前置代理，就在后面显示选项控制是否要使用代理。
- 如果规则节点设置为和前置代理同一节点，则开关无效，前置代理不会使用。（关于这点，本来想做成隐藏代理开关。还有前置代理总设置关闭时，也想在界面上隐藏规则的代理开关的，但限于luci的depends逻辑关系处理实在太弱，要实现，需要的depends项大概是节点总数的平方）


测试情况：
【Xray/V2ray负载均衡节点】
- ✅ 规则/默认 使用 Xray节点（Trojan） 组成的均衡节点，成功翻墙并成功负载均衡。
- ✅ 规则/默认 使用 非Xray节点（ss+obfs） 组成的均衡节点，成功翻墙并成功负载均衡。

【前置代理】
- 使用负载均衡作前置代理，之前是使用发送到dokodemo-door，然后修改目的地址和端口再路由到balancer的方式，现在改为使用特殊outbound协议`loopback`加路由规则，为 balancer 提供等效的 outboundTag，Xray内置协议的节点可直接使用proxySettings来设置 balancer 作为代理，对于非Xray节点，直接添加一条规则将原本的dokodemo-door路由到balancer。
 1）✅ 默认节点设置为Xray节点（Trojan），配置文件使用proxySettings设置前置代理到`loopback`的outboundTag。
 2）✅ 默认节点设置为非Xray节点（ss+obfs），成功翻墙，配置文件正确。


- ✅ 使用 Xray节点（Trojan） 组成的负载均衡节点作为前置代理，默认使用大陆无法访问的节点，成功解锁被封节点，查询机场使用记录，有多个来自负载均衡节点的 IP。
- ✅ 使用 非Xray节点（ss+obfs） 组成的负载均衡节点作为前置代理，重复上一个测试，成功。


- ✅ 默认 和 前置代理设置同一个节点（因为负载均衡目前设计成不能应用前置代理，所以两个均为单节点），并启用前置代理，成功上网，检查生成的配置，默认节点实际未启用前置代理。
