### PR TITLE
luci: app_update use default_path when not set in config

### DIFF
--- a/luci-app-passwall/luasrc/passwall/api.lua
+++ b/luci-app-passwall/luasrc/passwall/api.lua
@@ -413,7 +413,9 @@ local function get_bin_version_cache(file, cmd)
 end
 
 function get_app_path(app_name)
+	local def_path = com[app_name].default_path
 	local path = uci_get_type("global_app", app_name:gsub("%-","_") .. "_file")
+	path = path and (#path>0 and path or def_path) or def_path
 	return path
 end
 


### PR DESCRIPTION
这个是为了解决有些人提出的更新之后，新增的组件没法直接更新，需要点一次保存应用之后才能更新的问题。不过看了一下错误提示，其实这个问题应该很早就存在了，而且错误提示中给出了解决办法，就是点击保存&应用之后再更新就可以了。不过貌似是不是都只看一半，只看到前面的，没看到后面的给出的解决方法。所以，我感觉这个合不合无所谓，其实现在这样挺好的，都给出提示了。