### PR TITLE
luci: balancing add strategy option & remove unnesscary options

### DIFF
--- a/luci-app-passwall/luasrc/model/cbi/passwall/client/node_config.lua
+++ b/luci-app-passwall/luasrc/model/cbi/passwall/client/node_config.lua
@@ -153,6 +153,7 @@ balancingStrategy.default = "random"
 local probeInterval = s:option(Value, "probeInterval", translate("Probe Interval"))
 probeInterval:depends("balancingStrategy", "leastPing")
 probeInterval.default = "1m"
+probeInterval.description = translate("The interval between initiating probes. Every time this time elapses, a server status check is performed on a server. The time format is numbers + units, such as '10s', '2h45m', and the supported time units are <code>ns</code>, <code>us</code>, <code>ms</code>, <code>s</code>, <code>m</code>, <code>h</code>, which correspond to nanoseconds, microseconds, milliseconds, seconds, minutes, and hours, respectively.")
 
 -- 分流
 uci:foreach(appname, "shunt_rules", function(e)

--- a/luci-app-passwall/luasrc/model/cbi/passwall/client/node_config.lua
+++ b/luci-app-passwall/luasrc/model/cbi/passwall/client/node_config.lua
@@ -142,9 +142,17 @@ for k, e in ipairs(api.get_valid_nodes()) do
 end
 
 -- 负载均衡列表
-balancing_node = s:option(DynamicList, "balancing_node", translate("Load balancing node list"), translate("Load balancing node list, <a target='_blank' href='https://toutyrater.github.io/routing/balance2.html'>document</a>"))
+local balancing_node = s:option(DynamicList, "balancing_node", translate("Load balancing node list"), translate("Load balancing node list, <a target='_blank' href='https://toutyrater.github.io/routing/balance2.html'>document</a>"))
 for k, v in pairs(nodes_table) do balancing_node:value(v.id, v.remarks) end
 balancing_node:depends("protocol", "_balancing")
+local balancingStrategy = s:option(ListValue, "balancingStrategy", translate("Balancing Strategy"))
+balancingStrategy:depends("protocol", "_balancing")
+balancingStrategy:value("random")
+balancingStrategy:value("leastPing")
+balancingStrategy.default = "random"
+local probeInterval = s:option(Value, "probeInterval", translate("Probe Interval"))
+probeInterval:depends("balancingStrategy", "leastPing")
+probeInterval.default = "1m"
 
 -- 分流
 uci:foreach(appname, "shunt_rules", function(e)
@@ -205,13 +213,11 @@ domainStrategy.description = "<br /><ul><li>" .. translate("'AsIs': Only use dom
 .. "</li><li>" .. translate("'IPIfNonMatch': When no rule matches current domain, resolves it into IP addresses (A or AAAA records) and try all rules again.")
 .. "</li><li>" .. translate("'IPOnDemand': As long as there is a IP-based rule, resolves the domain into IP immediately.")
 .. "</li></ul>"
-domainStrategy:depends("protocol", "_balancing")
 domainStrategy:depends("protocol", "_shunt")
 
 domainMatcher = s:option(ListValue, "domainMatcher", translate("Domain matcher"))
 domainMatcher:value("hybrid")
 domainMatcher:value("linear")
-domainMatcher:depends("protocol", "_balancing")
 domainMatcher:depends("protocol", "_shunt")
 
 

--- a/luci-app-passwall/luasrc/passwall/util_xray.lua
+++ b/luci-app-passwall/luasrc/passwall/util_xray.lua
@@ -527,6 +527,7 @@ function gen_config(var)
 	local dns = nil
 	local fakedns = nil
 	local routing = nil
+	local observatory = nil
 	local inbounds = {}
 	local outbounds = {}
 
@@ -791,10 +792,18 @@ function gen_config(var)
 					local outbound = gen_outbound(flag, node)
 					if outbound then table.insert(outbounds, outbound) end
 				end
+				if node.balancingStrategy == "leastPing" then
+					observatory = {
+						subjectSelector = nodes,
+						probeInterval = node.probeInterval or "1m"
+					}
+				end
 				routing = {
-					domainStrategy = node.domainStrategy or "AsIs",
-					domainMatcher = node.domainMatcher or "hybrid",
-					balancers = {{tag = "balancer", selector = nodes}},
+					balancers = {{
+						tag = "balancer",
+						selector = nodes,
+						strategy = {type = node.balancingStrategy or "random"}
+					}},
 					rules = {
 						{type = "field", network = "tcp,udp", balancerTag = "balancer"}
 					}
@@ -1039,6 +1048,8 @@ function gen_config(var)
 			inbounds = inbounds,
 			-- 传出连接
 			outbounds = outbounds,
+			-- 连接观测
+			observatory = observatory,
 			-- 路由
 			routing = routing,
 			-- 本地策略

--- a/luci-app-passwall/po/zh-cn/passwall.po
+++ b/luci-app-passwall/po/zh-cn/passwall.po
@@ -352,6 +352,9 @@ msgstr "负载均衡策略"
 msgid "Probe Interval"
 msgstr "探测间隔"
 
+msgid "The interval between initiating probes. Every time this time elapses, a server status check is performed on a server. The time format is numbers + units, such as '10s', '2h45m', and the supported time units are <code>ns</code>, <code>us</code>, <code>ms</code>, <code>s</code>, <code>m</code>, <code>h</code>, which correspond to nanoseconds, microseconds, milliseconds, seconds, minutes, and hours, respectively."
+msgstr "发起探测的间隔。每经过这个时间，就会对一个服务器进行服务器状态检测。时间格式为数字+单位，比如<code>&quot;10s&quot;</code>, <code>&quot;2h45m&quot;</code>，支持的时间单位有 <code>ns</code>，<code>us</code>，<code>ms</code>，<code>s</code>，<code>m</code>，<code>h</code>，分别对应纳秒、微秒、毫秒、秒、分、时。"
+
 msgid "Shunt"
 msgstr "分流"
 

--- a/luci-app-passwall/po/zh-cn/passwall.po
+++ b/luci-app-passwall/po/zh-cn/passwall.po
@@ -346,6 +346,12 @@ msgstr "Xray 负载均衡"
 msgid "V2ray_balancing"
 msgstr "V2ray 负载均衡"
 
+msgid "Balancing Strategy"
+msgstr "负载均衡策略"
+
+msgid "Probe Interval"
+msgstr "探测间隔"
+
 msgid "Shunt"
 msgstr "分流"
 


### PR DESCRIPTION
根据[此处](https://github.com/xiaorouji/openwrt-passwall/pull/2402#issuecomment-1482143893)的讨论，给负载均衡节点添加了均衡策略的选项。
还有在单独使用负载均衡节点时，域名匹配策略和算法其实都是用不上的，全部流量都走这一个balancer出去了。所以对负载均衡节点的设置禁用了这两个选项。
对于LeastPing策略需要的探测时间间隔参数的设置，添加了描述，内容取自V2ray官方文档中对这一参数的说明。