### PR TITLE
luci: app update uses upx to compress binary

### DIFF
--- a/luci-app-passwall/luasrc/controller/passwall.lua
+++ b/luci-app-passwall/luasrc/controller/passwall.lua
@@ -71,10 +71,12 @@ function index()
 	--[[Components update]]
 	entry({"admin", "services", appname, "check_passwall"}, call("app_check")).leaf = true
 	local coms = require "luci.passwall.com"
-	local com
-	for com, _ in pairs(coms) do
-		entry({"admin", "services", appname, "check_" .. com}, call("com_check", com)).leaf = true
-		entry({"admin", "services", appname, "update_" .. com}, call("com_update", com)).leaf = true
+	local k, v
+	for k, v in pairs(coms) do
+		if not v.hide then
+			entry({"admin", "services", appname, "check_" .. k}, call("com_check", k)).leaf = true
+			entry({"admin", "services", appname, "update_" .. k}, call("com_update", k)).leaf = true
+		end
 	end
 end
 

--- a/luci-app-passwall/luasrc/model/cbi/passwall/client/app_update.lua
+++ b/luci-app-passwall/luasrc/model/cbi/passwall/client/app_update.lua
@@ -14,9 +14,11 @@ s:append(Template(appname .. "/app_update/app_version"))
 local k, v
 local com = require "luci.passwall.com"
 for k, v in pairs(com) do
-	o = s:option(Value, k:gsub("%-","_") .. "_file", translatef("%s App Path", v.name))
-	o.default = v.default_path or ("/usr/bin/"..k)
-	o.rmempty = false
+	if not v.hide then
+		o = s:option(Value, k:gsub("%-","_") .. "_file", translatef("%s App Path", v.name))
+		o.default = v.default_path or ("/usr/bin/"..k)
+		o.rmempty = false
+	end
 end
 
 o = s:option(DummyValue, "tips", " ")

--- a/luci-app-passwall/luasrc/passwall/com.lua
+++ b/luci-app-passwall/luasrc/passwall/com.lua
@@ -8,6 +8,33 @@ local function gh_pre_release_url(self)
 	return "https://api.github.com/repos/" .. self.repo .. "/releases?per_page=1"
 end
 
+local function gh_file_url(self, arch)
+	return "https://raw.githubusercontent.com/".. self.repo .. string.format(self.path_fmt_str, self.file_tree[arch])
+end
+
+--Supported arch name: x86_64, x86, mips, mipsel, aarch64, armv5, armv6, armv7
+
+_M.upx = {
+	name = "UPX",
+	repo = "nftbty/op-tools-dl",
+	get_dl_url = gh_file_url,
+	cmd_version = "-V | sed -n 1P | awk '{print $2}'",
+	zipped = false,
+	hide = false,
+	default_path = "/usr/bin/upx",
+	path_fmt_str = "/main/upx/upx_%s",
+	file_tree = {
+		x86_64 = "amd64",
+		x86 = "i386",
+		mips = "mips",
+		mipsel = "mipsel",
+		aarch64 = "arm64",
+		armv5 = "arm",
+		armv6 = "arm",
+		armv7 = "arm"
+	}
+}
+
 _M.brook = {
 	name = "Brook",
 	repo = "txthinking/brook",

--- a/luci-app-passwall/luasrc/view/passwall/app_update/app_version.htm
+++ b/luci-app-passwall/luasrc/view/passwall/app_update/app_version.htm
@@ -187,7 +187,8 @@ local version = {}
 </div>
 
 <%for k, v in pairs(com) do
-	version[k] = api.get_app_version(k)%>
+	if not v.hide then
+		version[k] = api.get_app_version(k)%>
 <div class="cbi-value">
 	<label class="cbi-value-title"><%=v.name%>
 		<%:Version%>
@@ -201,4 +202,5 @@ local version = {}
 		</div>
 	</div>
 </div>
-<%end%>
+<%	end
+end%>


### PR DESCRIPTION
组件更新中几乎全部组件都是Go程序，太占空间，而且后来更新的也不像随系统编译的的有 squashfs 压缩。所以想到用upx压缩一下。
本来想把upx加到com里面下载的，但是upx官方发布的.tar.xz包，一般openwrt应该都没装 xz 和 tar，这样弄基本就会是个摆设。而upx 也不需要追新，所以建了个仓库，把upx官方发布的几个linux版本全部解压上传上去了，然后做成了直接从这个仓库下载upx。
试了一下默认参数，V2ray 21M，能压到6.7M，但是太慢，然后试了几个级别，感觉 `-3`还可以，不至于太慢，压缩率也还可以，能把V2ray压到大概9.4M。