### PR TITLE
luci: add advanced log feature #2424

### DIFF
--- a/luci-app-passwall/luasrc/model/cbi/passwall/client/global.lua
+++ b/luci-app-passwall/luasrc/model/cbi/passwall/client/global.lua
@@ -117,7 +117,7 @@ if (has_v2ray or has_xray) and #nodes_table > 0 then
 			shunt_list[#shunt_list + 1] = v
 		end
 	end
-	
+
 	local function get_cfgvalue(shunt_node_id, rule_id)
 		return function(self, section)
 			return m:get(shunt_node_id, rule_id) or "nil"
@@ -419,6 +419,16 @@ trojan_loglevel:value("1", "info")
 trojan_loglevel:value("2", "warn")
 trojan_loglevel:value("3", "error")
 trojan_loglevel:value("4", "fatal")
+
+o = s:taboption("log", Flag, "advanced_log_feature", translate("Advanced log feature"), translate("For professionals only."))
+o.default = "0"
+o.rmempty = false
+local syslog = s:taboption("log", Flag, "sys_log", translate("Logging to system log"), translate("Logging to the system log for more advanced functions. For example, send logs to a dedicated log server."))
+syslog:depends("advanced_log_feature", "1")
+syslog.default = "0"
+syslog.rmempty = false
+local logpath = s:taboption("log", Value, "persist_log_path", translate("Persist log file directory"), translate("The path to the directory used to store persist log files, the \"/\" at the end can be omitted. Leave it blank to disable this feature."))
+logpath:depends({ ["advanced_log_feature"] = 1, ["sys_log"] = 0 })
 
 s:tab("faq", "FAQ")
 

--- a/luci-app-passwall/po/zh-cn/passwall.po
+++ b/luci-app-passwall/po/zh-cn/passwall.po
@@ -1288,6 +1288,24 @@ msgstr "%s 节点日志关闭"
 msgid "Log Level"
 msgstr "日志等级"
 
+msgid "Advanced log feature"
+msgstr "高级日志功能"
+
+msgid "For professionals only."
+msgstr "仅限专业人士使用。"
+
+msgid "Persist log file directory"
+msgstr "持久性日志文件目录"
+
+msgid "The path to the directory used to store persist log files, the \"/\" at the end can be omitted. Leave it blank to disable this feature."
+msgstr "用来存储持久性日志文件的目录路径，末尾的 “/” 可以省略。留空以禁用此功能。"
+
+msgid "Logging to system log"
+msgstr "记录到系统日志"
+
+msgid "Logging to the system log for more advanced functions. For example, send logs to a dedicated log server."
+msgstr "将日志记录到系统日志，以实现更加高级的功能。例如，把日志发送到专门的日志服务器。"
+
 msgid "Not enabled log"
 msgstr "未启用日志"
 


### PR DESCRIPTION
由最开始 #2424 提出的功能请求和之后的讨论，最终做出了这个“高级日志功能”，主要用于专业人员用于持久保存日志。有两种方式。
- 指定硬盘目录，将日志文件写入，日志文件命名以 `passwall_TCP_xray_2023-04-01.log` 这样的格式。（测试中发现，可以开启0点自动更新规则重启passwall，实现0点日志自动滚动。）
- 将日志记录到系统日志，以借助系统日志功能实现更加高级的使用场景，比如讨论中提到的利用系统日志将日志发送到专门的日志服务器。