### PR TITLE
luci:  optimize passwall check update tips

### DIFF
--- a/luci-app-passwall/luasrc/passwall/api.lua
+++ b/luci-app-passwall/luasrc/passwall/api.lua
@@ -876,6 +876,6 @@ function to_check_self()
 		has_update = true,
 		local_version = local_version,
 		remote_version = remote_version,
-		error = remote_version
+		error = i18n.translatef("The latest version: %s, currently does not support automatic update, if you need to update, please compile or download the ipk and then manually install.", remote_version)
 	}
 end

--- a/luci-app-passwall/luasrc/view/passwall/app_update/app_version.htm
+++ b/luci-app-passwall/luasrc/view/passwall/app_update/app_version.htm
@@ -9,7 +9,7 @@ local version = {}
 	var appInfoList = new Array();
 	var inProgressCount = 0;
 	var tokenStr = '<%=token%>';
-	var manuallyUpdateText = '<%:Manually update%>';
+	var checkUpdateText = '<%:Check update%>';
 	var noUpdateText = '<%:It is the latest version%>';
 	var updateSuccessText = '<%:Update successful%>';
 	var clickToUpdateText = '<%:Click to update%>';
@@ -55,7 +55,7 @@ local version = {}
 
 	function onRequestError(btn, errorMessage) {
 		btn.disabled = false;
-		btn.value = manuallyUpdateText;
+		btn.value = checkUpdateText;
 
 		var ckeckDetailElm = document.getElementById(btn.id + '-detail');
 		if (errorMessage && ckeckDetailElm) {
@@ -180,7 +180,7 @@ local version = {}
 		<div class="cbi-value-description">
 			<span>【 <%=api.get_version()%> 】</span>
 			<input class="btn cbi-button cbi-button-apply" type="button" id="passwall-check_btn"
-				onclick="onBtnClick(this,'passwall');" value="<%:Manually update%>" />
+				onclick="onBtnClick(this,'passwall');" value="<%:Check update%>" />
 			<span id="passwall-check_btn-detail"></span>
 		</div>
 	</div>
@@ -196,7 +196,7 @@ local version = {}
 		<div class="cbi-value-description">
 			<span>【 <%=version[k] ~="" and version[k] or translate("Null") %> 】</span>
 			<input class="btn cbi-button cbi-button-apply" type="button" id="_<%=k%>-check_btn"
-				onclick="onBtnClick(this,'<%=k%>');" value="<%:Manually update%>" />
+				onclick="onBtnClick(this,'<%=k%>');" value="<%:Check update%>" />
 			<span id="_<%=k%>-check_btn-detail"></span>
 		</div>
 	</div>

--- a/luci-app-passwall/po/zh-cn/passwall.po
+++ b/luci-app-passwall/po/zh-cn/passwall.po
@@ -757,8 +757,14 @@ msgstr "主要"
 msgid "Standby"
 msgstr "备用"
 
+msgid "Check update"
+msgstr "检查更新"
+
 msgid "Manually update"
 msgstr "手动更新"
+
+msgid "The latest version: %s, currently does not support automatic update, if you need to update, please compile or download the ipk and then manually install."
+msgstr "最新版本：%s，目前暂不支持自动更新，如需更新，请自行编译或下载ipk然后手动安装。"
 
 msgid "Enable custom URL"
 msgstr "启用自定义规则地址"


### PR DESCRIPTION
鉴于最近总是有人提issue问关于自更新的问题，所以把检测更新的提示优化了一下，然后原来的“手动更新”感觉不是太合适，改成了“检查更新”。