### PR TITLE
luci: fix bug introduced in #2438

### DIFF
--- a/luci-app-passwall/luasrc/passwall/util_xray.lua
+++ b/luci-app-passwall/luasrc/passwall/util_xray.lua
@@ -817,6 +817,7 @@ function gen_config(var)
 						table.insert(rules, {
 							type = "field",
 							outboundTag = outboundTag,
+							balancerTag = balancerTag,
 							domain = _domain,
 							protocol = protocols
 						})
@@ -829,6 +830,7 @@ function gen_config(var)
 						table.insert(rules, {
 							type = "field",
 							outboundTag = outboundTag,
+							balancerTag = balancerTag,
 							ip = _ip,
 							protocol = protocols
 						})
@@ -837,6 +839,7 @@ function gen_config(var)
 						table.insert(rules, {
 							type = "field",
 							outboundTag = outboundTag,
+							balancerTag = balancerTag,
 							protocol = protocols
 						})
 					end


### PR DESCRIPTION
上午有点忙，加上为了能尽快解决#2434 的问题，着急之下直接把那段代码恢复成之前不支持balancerTag的版本了，三个规则都掉了`balancerTag = balancerTag,`，刚刚把路由上的换成最新版，发现规则里用了Xray均衡节点就运行不起来，才想起这个问题。