### PR TITLE
luci: fix & optimize shunt config

### DIFF
--- a/luci-app-passwall/po/zh-cn/passwall.po
+++ b/luci-app-passwall/po/zh-cn/passwall.po
@@ -397,6 +397,9 @@ msgstr "黑洞"
 msgid "Default Preproxy"
 msgstr "默认前置代理"
 
+msgid "There are no available nodes, please add or subscribe nodes first."
+mststr "没有可用节点，请先添加或订阅节点。"
+
 msgid "No shunt rules? Click me to go to add."
 msgstr "没有分流规则？点我前往去添加。"
 


### PR DESCRIPTION
- [这里](https://github.com/xiaorouji/openwrt-passwall/issues/2433#issuecomment-1493487760)提出了在初始配置，只有分流总结点，没添加普通节点的时候，主设置界面和节点设置界面会有异常。修复了这个问题，并进一步对无可用节点情况下的界面显示做了优化。
- 当系统上同时安装Xray和V2ray时，主界面分流设置显示类型选项，方便切换。对于系统上只装了一种的，和原来一样，不会显示“类型”。