### PR TITLE
luci: modify version use PKG_VERSION only

### DIFF
--- a/luci-app-passwall/Makefile
+++ b/luci-app-passwall/Makefile
@@ -6,8 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=luci-app-passwall
-PKG_VERSION:=4.63
-PKG_RELEASE:=1
+PKG_VERSION:=4.63-1
 
 PKG_CONFIG_DEPENDS:= \
 	CONFIG_PACKAGE_$(PKG_NAME)_Iptables_Transparent_Proxy \


### PR DESCRIPTION
由于使用官方SDK编译只会以`PKG_VERSION`生成版本号，并不会管PKG_RELEASE，给更新和显示当前版本带来一定麻烦。查了几个官方收录的带版本号的luci app，采用的是直接在`PKG_VERSION`后面带上`-1`这种方式，并没有使用`PKG_RELEASE`。为了方便更新和检查当前版本号，建议也更改为这种方式。