### PR TITLE
luci: wireguard reserved support base64 string

### DIFF
--- a/luci-app-passwall/luasrc/model/cbi/passwall/client/node_config.lua
+++ b/luci-app-passwall/luasrc/model/cbi/passwall/client/node_config.lua
@@ -749,7 +749,7 @@ wireguard_mtu.default = "1420"
 wireguard_mtu:depends({ type = "Xray", protocol = "wireguard" })
 
 if api.compare_versions(api.get_app_version("xray"), ">=", "1.8.0") then
-	wireguard_reserved = s:option(Value, "wireguard_reserved", translate("Reserved"))
+	wireguard_reserved = s:option(Value, "wireguard_reserved", translate("Reserved"), translate("Decimal numbers separated by \",\" or Base64-encoded strings."))
 	wireguard_reserved:depends({ type = "Xray", protocol = "wireguard" })
 end
 

--- a/luci-app-passwall/luasrc/passwall/api.lua
+++ b/luci-app-passwall/luasrc/passwall/api.lua
@@ -1,5 +1,6 @@
 module("luci.passwall.api", package.seeall)
 local com = require "luci.passwall.com"
+bin = require "nixio".bin
 fs = require "nixio.fs"
 sys = require "luci.sys"
 uci = require"luci.model.uci".cursor()

--- a/luci-app-passwall/luasrc/passwall/util_xray.lua
+++ b/luci-app-passwall/luasrc/passwall/util_xray.lua
@@ -102,9 +102,16 @@ function gen_outbound(flag, node, tag, proxy_table)
 
 		if node.protocol == "wireguard" and node.wireguard_reserved then
 			local bytes = {}
-			node.wireguard_reserved:gsub("[^,]+", function(b)
-				bytes[#bytes+1] = tonumber(b)
-			end)
+			if not node.wireguard_reserved:match("[^%d,]+") then
+				node.wireguard_reserved:gsub("%d+", function(b)
+					bytes[#bytes + 1] = tonumber(b)
+				end)
+			else
+				local result = api.bin.b64decode(node.wireguard_reserved)
+				for i = 1, #result do
+					bytes[i] = result:byte(i)
+				end
+			end
 			node.wireguard_reserved = #bytes > 0 and bytes or nil
 		end
 

--- a/luci-app-passwall/po/zh-cn/passwall.po
+++ b/luci-app-passwall/po/zh-cn/passwall.po
@@ -1117,6 +1117,9 @@ msgstr "额外的对称加密密钥"
 msgid "Local Address"
 msgstr "本地地址"
 
+msgid "Decimal numbers separated by \",\" or Base64-encoded strings."
+msgstr "用“,”隔开的十进制数字或 Base64 编码字符串。"
+
 msgid "Camouflage Type"
 msgstr "伪装类型"
 


### PR DESCRIPTION
从有些软件提取的 Warp 配置，Reserved 是 Base64 编码的。为免手动转码的麻烦，支持在 Reserved 直接填入 Base64 字符串。