### PR TITLE
Fixed #2716

### DIFF
--- a/luci-app-passwall/root/usr/share/passwall/nftables.sh
+++ b/luci-app-passwall/root/usr/share/passwall/nftables.sh
@@ -183,7 +183,7 @@ get_redirect_ipv6() {
 		echo "ip6 daddr @$NFTSET_GFW6 $(REDIRECT $2 $3)"
 		;;
 	chnroute)
-		echo "ip6 daddr != { $(cat $RULES_PATH/chnroute6 | tr -s '\n' | grep -v '^#' | sed -e '/^$/d' | sed ':a;N;$!ba;s/\n/, /g') } $(REDIRECT $2 $3)"
+		echo "ip6 daddr != @$NFTSET_CHN6 $(REDIRECT $2 $3)"
 		;;
 	returnhome)
 		echo "ip6 daddr $NFTSET_CHN6 $(REDIRECT $2 $3)"

--- a/luci-app-passwall/root/usr/share/passwall/nftables.sh
+++ b/luci-app-passwall/root/usr/share/passwall/nftables.sh
@@ -183,7 +183,7 @@ get_redirect_ipv6() {
 		echo "ip6 daddr @$NFTSET_GFW6 $(REDIRECT $2 $3)"
 		;;
 	chnroute)
-		echo "ip6 daddr != $NFTSET_CHN6 $(REDIRECT $2 $3)"
+		echo "ip6 daddr != { $(cat $RULES_PATH/chnroute6 | tr -s '\n' | grep -v '^#' | sed -e '/^$/d' | sed ':a;N;$!ba;s/\n/, /g') } $(REDIRECT $2 $3)"
 		;;
 	returnhome)
 		echo "ip6 daddr $NFTSET_CHN6 $(REDIRECT $2 $3)"


### PR DESCRIPTION
https://github.com/xiaorouji/openwrt-passwall/issues/2716

nft并不支持目前仓库里的 `!=`直接加nft set语法。

根据[快速手册](https://wiki.nftables.org/wiki-nftables/index.php/Quick_reference-nftables_in_10_minutes)

引用的nftable set，需要加一个`@`符号。实测，修改后，在`nftables`模式下，`service passwall restart `不会再有报错信息输出。