### PR TITLE
dnsmasq filtering IPv6 when chinadns-ng is enabled

### DIFF
--- a/luci-app-passwall/root/usr/share/passwall/app.sh
+++ b/luci-app-passwall/root/usr/share/passwall/app.sh
@@ -1214,7 +1214,6 @@ stop_crontab() {
 
 start_dns() {
 	TUN_DNS="127.0.0.1#${dns_listen_port}"
-	DNSMASQ_FILTER_IPV6=$FILTER_PROXY_IPV6
 
 	echolog "过滤服务配置：准备接管域名解析..."
 	[ "$ENABLED_ACLS" == 1 ] && {
@@ -1329,7 +1328,6 @@ start_dns() {
 	[ "$CHINADNS_NG" = "1" ] && [ -n "$(first_type chinadns-ng)" ] && ([ -n "$chnlist" ] || [ -n "$gfwlist" ]) && {
 		[ "$FILTER_PROXY_IPV6" = "1" ] && {
 			local _no_ipv6_rules="gt"
-			DNSMASQ_FILTER_IPV6=0
 		}
 		local china_ng_listen_port=$(expr $dns_listen_port + 1)
 		local china_ng_listen="127.0.0.1#${china_ng_listen_port}"
@@ -1354,7 +1352,7 @@ start_dns() {
 		lua $APP_PATH/helper_dnsmasq_add.lua -FLAG "default" -TMP_DNSMASQ_PATH ${TMP_DNSMASQ_PATH} \
 			-DNSMASQ_CONF_FILE "/tmp/dnsmasq.d/dnsmasq-passwall.conf" -DEFAULT_DNS ${DEFAULT_DNS} -LOCAL_DNS ${LOCAL_DNS} \
 			-TUN_DNS ${TUN_DNS} -REMOTE_FAKEDNS ${fakedns:-0} -CHNROUTE_MODE_DEFAULT_DNS "${WHEN_CHNROUTE_DEFAULT_DNS:-direct}" -CHINADNS_DNS ${china_ng_listen:-0} \
-			-TCP_NODE ${TCP_NODE} -PROXY_MODE "${TCP_PROXY_MODE}${LOCALHOST_TCP_PROXY_MODE}${ACL_TCP_PROXY_MODE}" -NO_PROXY_IPV6 ${DNSMASQ_FILTER_IPV6:-0} -NFTFLAG ${nftflag:-0} \
+			-TCP_NODE ${TCP_NODE} -PROXY_MODE "${TCP_PROXY_MODE}${LOCALHOST_TCP_PROXY_MODE}${ACL_TCP_PROXY_MODE}" -NO_PROXY_IPV6 ${FILTER_PROXY_IPV6:-0} -NFTFLAG ${nftflag:-0} \
 			-NO_LOGIC_LOG ${NO_LOGIC_LOG:-0}
 	}
 }
@@ -1482,11 +1480,9 @@ acl_app() {
 								eval node_${tcp_node}_$(echo -n "${remote_dns}" | md5sum | cut -d " " -f1)=${_dns_port}
 							}
 
-							local _dnsmasq_filter_ipv6=$filter_proxy_ipv6
 							[ "$chinadns_ng" = "1" ] && [ -n "$(first_type chinadns-ng)" ] && ([ "$tcp_proxy_mode" = "chnroute" ] || [ "$tcp_proxy_mode" = "gfwlist" ]) && {
 								[ "$filter_proxy_ipv6" = "1" ] && {
 									local _no_ipv6_rules="gt"
-									_dnsmasq_filter_ipv6=0
 								}
 								chinadns_port=$(expr $chinadns_port + 1)
 								_china_ng_listen="127.0.0.1#${chinadns_port}"
@@ -1532,7 +1528,7 @@ acl_app() {
 							lua $APP_PATH/helper_dnsmasq_add.lua -FLAG ${sid} -TMP_DNSMASQ_PATH $TMP_ACL_PATH/$sid/dnsmasq.d \
 								-DNSMASQ_CONF_FILE $TMP_ACL_PATH/$sid/dnsmasq.conf -DEFAULT_DNS $DEFAULT_DNS -LOCAL_DNS $LOCAL_DNS \
 								-TUN_DNS "127.0.0.1#${_dns_port}" -REMOTE_FAKEDNS 0 -CHNROUTE_MODE_DEFAULT_DNS "${when_chnroute_default_dns:-direct}" -CHINADNS_DNS ${_china_ng_listen:-0} \
-								-TCP_NODE $tcp_node -PROXY_MODE ${tcp_proxy_mode} -NO_PROXY_IPV6 ${_dnsmasq_filter_ipv6:-0} -NFTFLAG ${nftflag:-0} \
+								-TCP_NODE $tcp_node -PROXY_MODE ${tcp_proxy_mode} -NO_PROXY_IPV6 ${filter_proxy_ipv6:-0} -NFTFLAG ${nftflag:-0} \
 								-NO_LOGIC_LOG 1
 							ln_run "$(first_type dnsmasq)" "dnsmasq_${sid}" "/dev/null" -C $TMP_ACL_PATH/$sid/dnsmasq.conf -x $TMP_ACL_PATH/$sid/dnsmasq.pid
 							eval node_${tcp_node}_$(echo -n "${tcp_proxy_mode}${remote_dns}" | md5sum | cut -d " " -f1)=${dnsmasq_port}
@@ -1650,7 +1646,7 @@ acl_app() {
 			[ -n "$redirect_dns_port" ] && echo "${redirect_dns_port}" > $TMP_ACL_PATH/$sid/var_redirect_dns_port
 			unset enabled sid remarks sources tcp_proxy_mode udp_proxy_mode tcp_node udp_node filter_proxy_ipv6 dns_mode remote_dns v2ray_dns_mode remote_dns_doh dns_client_ip
 			unset _ip _mac _iprange _ipset _ip_or_mac rule_list tcp_port udp_port config_file _extra_param
-			unset _china_ng_listen _china_ng_chn _china_ng_gfw _gfwlist_file _chnlist_file _china_ng_log_file _no_ipv6_rules _china_ng_extra_param _dnsmasq_filter_ipv6
+			unset _china_ng_listen _china_ng_chn _china_ng_gfw _gfwlist_file _chnlist_file _china_ng_log_file _no_ipv6_rules _china_ng_extra_param
 			unset redirect_dns_port
 		done
 		unset socks_port redir_port dns_port dnsmasq_port chinadns_port

--- a/luci-app-passwall/root/usr/share/passwall/app.sh
+++ b/luci-app-passwall/root/usr/share/passwall/app.sh
@@ -511,7 +511,7 @@ run_chinadns_ng() {
 	
 	([ -n "$_chnlist" ] || [ -n "$_gfwlist" ]) && [ -s "${RULES_PATH}/gfwlist" ] && {
 		local _gfwlist_file="${TMP_PATH}/chinadns_gfwlist"
-		cp -a "${RULES_PATH}/gfwlist" "${_gfwlist_file}"
+		cp -a "${RULES_PATH}/gfwlist" "${_TCP_NODEgfwlist_file}"
 		local gfwlist_set="passwall_gfwlist,passwall_gfwlist6"
 		[ "$nftflag" = "1" ] && gfwlist_set="inet@fw4@passwall_gfwlist,inet@fw4@passwall_gfwlist6"
 		_extra_param="${_extra_param} -g ${_gfwlist_file} -A ${gfwlist_set}"

--- a/luci-app-passwall/root/usr/share/passwall/app.sh
+++ b/luci-app-passwall/root/usr/share/passwall/app.sh
@@ -511,7 +511,7 @@ run_chinadns_ng() {
 	
 	([ -n "$_chnlist" ] || [ -n "$_gfwlist" ]) && [ -s "${RULES_PATH}/gfwlist" ] && {
 		local _gfwlist_file="${TMP_PATH}/chinadns_gfwlist"
-		cp -a "${RULES_PATH}/gfwlist" "${_TCP_NODEgfwlist_file}"
+		cp -a "${RULES_PATH}/gfwlist" "${_gfwlist_file}"
 		local gfwlist_set="passwall_gfwlist,passwall_gfwlist6"
 		[ "$nftflag" = "1" ] && gfwlist_set="inet@fw4@passwall_gfwlist,inet@fw4@passwall_gfwlist6"
 		_extra_param="${_extra_param} -g ${_gfwlist_file} -A ${gfwlist_set}"

--- a/luci-app-passwall/root/usr/share/passwall/helper_dnsmasq_add.lua
+++ b/luci-app-passwall/root/usr/share/passwall/helper_dnsmasq_add.lua
@@ -222,7 +222,7 @@ if not fs.access(CACHE_DNS_PATH) then
 			add_excluded_domain(line)
 			local ipset_flag = setflag_4 .. "passwall_blacklist," .. setflag_6 .. "passwall_blacklist6"
 			if NO_PROXY_IPV6 == "1" then
-				set_domain_address(line, "::")
+					set_domain_address(line, "::")
 				ipset_flag = setflag_4 .. "passwall_blacklist"
 			end
 			if REMOTE_FAKEDNS == "1" then
@@ -286,66 +286,72 @@ if not fs.access(CACHE_DNS_PATH) then
 				end
 			end
 		end)
+	elseif only_global == 1 and NO_PROXY_IPV6 == "1" then
+		--节点：固定节点
+		--代理模式：全局模式
+		--过滤代理域名 IPv6：启用
+		--禁止解析所有IPv6记录
+		list1["#"] = {
+			dns = {},
+			ipsets = {},
+			address = "::"
+		}
 	end
 
-	--如果没有使用回国模式
-	if not returnhome then
-		if fs.access("/usr/share/passwall/rules/gfwlist") then
-			fwd_dns = TUN_DNS
-			if CHNROUTE_MODE_DEFAULT_DNS == "chinadns_ng" and CHINADNS_DNS ~= "0" then
-				fwd_dns = nil
-			else
-				local ipset_flag = setflag_4 .. "passwall_gfwlist," .. setflag_6 .. "passwall_gfwlist6"
-				if NO_PROXY_IPV6 == "1" then
-					ipset_flag = setflag_4 .. "passwall_gfwlist"
-				end
-				if not only_global then
+	if not only_global then
+		--如果没有使用回国模式
+		if not returnhome then
+			if fs.access("/usr/share/passwall/rules/gfwlist") then
+				fwd_dns = TUN_DNS
+				if CHNROUTE_MODE_DEFAULT_DNS == "chinadns_ng" and CHINADNS_DNS ~= "0" then
+					fwd_dns = nil
+				else
+					local ipset_flag = setflag_4 .. "passwall_gfwlist," .. setflag_6 .. "passwall_gfwlist6"
+					if NO_PROXY_IPV6 == "1" then
+						ipset_flag = setflag_4 .. "passwall_gfwlist"
+					end
 					if REMOTE_FAKEDNS == "1" then
 						ipset_flag = nil
 					end
-				end
-				local gfwlist_str = sys.exec('cat /usr/share/passwall/rules/gfwlist | grep -v -E "^#" | grep -v -E "' .. excluded_domain_str .. '"')
-				for line in string.gmatch(gfwlist_str, "[^\r\n]+") do
-					if line ~= "" then
-						if NO_PROXY_IPV6 == "1" then
-							set_domain_address(line, "::")
-						end
-						if not only_global then
+					local gfwlist_str = sys.exec('cat /usr/share/passwall/rules/gfwlist | grep -v -E "^#" | grep -v -E "' .. excluded_domain_str .. '"')
+					for line in string.gmatch(gfwlist_str, "[^\r\n]+") do
+						if line ~= "" then
+							if NO_PROXY_IPV6 == "1" then
+								set_domain_address(line, "::")
+							end
 							set_domain_dns(line, fwd_dns)
 							set_domain_ipset(line, ipset_flag)
 						end
 					end
 				end
+				log(string.format("  - 防火墙域名表(gfwlist)：%s", fwd_dns or "默认"))
 			end
-			log(string.format("  - 防火墙域名表(gfwlist)：%s", fwd_dns or "默认"))
-		end
 
-		if chnlist and fs.access("/usr/share/passwall/rules/chnlist") and (CHNROUTE_MODE_DEFAULT_DNS == "remote" or (CHNROUTE_MODE_DEFAULT_DNS == "chinadns_ng" and CHINADNS_DNS ~= "0")) then
-			fwd_dns = LOCAL_DNS
-			if CHNROUTE_MODE_DEFAULT_DNS == "chinadns_ng" and CHINADNS_DNS ~= "0" then
-				fwd_dns = nil
-			else
+			if chnlist and fs.access("/usr/share/passwall/rules/chnlist") and (CHNROUTE_MODE_DEFAULT_DNS == "remote" or (CHNROUTE_MODE_DEFAULT_DNS == "chinadns_ng" and CHINADNS_DNS ~= "0")) then
+				fwd_dns = LOCAL_DNS
+				if CHNROUTE_MODE_DEFAULT_DNS == "chinadns_ng" and CHINADNS_DNS ~= "0" then
+					fwd_dns = nil
+				else
+					local chnlist_str = sys.exec('cat /usr/share/passwall/rules/chnlist | grep -v -E "^#" | grep -v -E "' .. excluded_domain_str .. '"')
+					for line in string.gmatch(chnlist_str, "[^\r\n]+") do
+						if line ~= "" then
+							set_domain_dns(line, fwd_dns)
+							set_domain_ipset(line, setflag_4 .. "passwall_chnroute," .. setflag_6 .. "passwall_chnroute6")
+						end
+					end
+				end
+				log(string.format("  - 中国域名表(chnroute)：%s", fwd_dns or "默认"))
+			end
+		else
+			if fs.access("/usr/share/passwall/rules/chnlist") then
 				local chnlist_str = sys.exec('cat /usr/share/passwall/rules/chnlist | grep -v -E "^#" | grep -v -E "' .. excluded_domain_str .. '"')
 				for line in string.gmatch(chnlist_str, "[^\r\n]+") do
 					if line ~= "" then
-						set_domain_dns(line, fwd_dns)
-						set_domain_ipset(line, setflag_4 .. "passwall_chnroute," .. setflag_6 .. "passwall_chnroute6")
-					end
-				end
-			end
-			log(string.format("  - 中国域名表(chnroute)：%s", fwd_dns or "默认"))
-		end
-	else
-		if fs.access("/usr/share/passwall/rules/chnlist") then
-			local chnlist_str = sys.exec('cat /usr/share/passwall/rules/chnlist | grep -v -E "^#" | grep -v -E "' .. excluded_domain_str .. '"')
-			for line in string.gmatch(chnlist_str, "[^\r\n]+") do
-				if line ~= "" then
-					local ipset_flag = setflag_4 .. "passwall_chnroute," .. setflag_6 .. "passwall_chnroute6"
-					if NO_PROXY_IPV6 == "1" then
-						ipset_flag = setflag_4 .. "passwall_chnroute"
-						set_domain_address(line, "::")
-					end
-					if not only_global then
+						local ipset_flag = setflag_4 .. "passwall_chnroute," .. setflag_6 .. "passwall_chnroute6"
+						if NO_PROXY_IPV6 == "1" then
+							ipset_flag = setflag_4 .. "passwall_chnroute"
+							set_domain_address(line, "::")
+						end
 						set_domain_dns(line, TUN_DNS)
 						if REMOTE_FAKEDNS == "1" then
 							ipset_flag = nil
@@ -353,8 +359,8 @@ if not fs.access(CACHE_DNS_PATH) then
 						set_domain_ipset(line, ipset_flag)
 					end
 				end
+				log(string.format("  - 中国域名表(chnroute)：%s", TUN_DNS or "默认"))
 			end
-			log(string.format("  - 中国域名表(chnroute)：%s", TUN_DNS or "默认"))
 		end
 	end
 
@@ -366,8 +372,12 @@ if not fs.access(CACHE_DNS_PATH) then
 		set_name = "nftset"
 	end
 	for key, value in pairs(list1) do
-		if value.address and #value.address > 0 then
-			address_out:write(string.format("address=/.%s/%s\n", key, value.address))
+		if value.address then
+			local domain = "." .. key
+			if key == "#" then
+				domain = key
+			end
+			address_out:write(string.format("address=/%s/%s\n", domain, value.address))
 		end
 		if value.dns and #value.dns > 0 then
 			for i, dns in ipairs(value.dns) do

--- a/luci-app-passwall/root/usr/share/passwall/helper_dnsmasq_add.lua
+++ b/luci-app-passwall/root/usr/share/passwall/helper_dnsmasq_add.lua
@@ -222,7 +222,7 @@ if not fs.access(CACHE_DNS_PATH) then
 			add_excluded_domain(line)
 			local ipset_flag = setflag_4 .. "passwall_blacklist," .. setflag_6 .. "passwall_blacklist6"
 			if NO_PROXY_IPV6 == "1" then
-					set_domain_address(line, "::")
+				set_domain_address(line, "::")
 				ipset_flag = setflag_4 .. "passwall_blacklist"
 			end
 			if REMOTE_FAKEDNS == "1" then


### PR DESCRIPTION
修复当"ChinaDNS-NG"开启时"过滤代理域名 IPv6"无效

此功能应过滤所有代理域名的IPv6记录

当前使用正常情景如下：
```
节点: "固定节点" / "Xray分流"
代理模式："全局模式" / "GFW列表" / "中国列表以外" / "中国列表"
ChinaDNS-NG: "关闭"
```


已知问题：
1. 无法过滤"Xray分流规则"中的"正则表达式(regexp:)"、"预定义域名列表(geosite:)"、"从文件中加载域名(ext:)"
2. 在"全局模式"下使用"固定节点"会禁用全局IPv6记录，此功能在Dnsmasq 2.86版本中不可用

此PR修复以下情景：
```
节点: "固定节点"
代理模式："全局模式"
ChinaDNS-NG: "开启"
目前情况：不过滤所有的IPv6记录
修复后：
- Dnsmasq负责过滤所有IPv6记录，放过"直连列表"


节点: "Xray分流"
代理模式："全局模式"
ChinaDNS-NG: "开启"
目前情况：不过滤所有的IPv6记录
修复后：
- Dnsmasq负责过滤"规则列表"、"Xray分流规则(部分)"


节点: "固定节点" / "Xray分流"
代理模式："GFW列表" / "中国列表以外"
ChinaDNS-NG: "开启"
目前情况：过滤"gfwlist"、"可信上游DNS"，遗漏"规则列表"、"Xray分流规则"
修复后：
- Dnsmasq负责过滤"规则列表"、"Xray分流规则(部分)"
- ChinaDNS-NG负责过滤"gfwlist"、"可信上游DNS"


节点: "固定节点" / "Xray分流"
代理模式："中国列表"
ChinaDNS-NG: "开启"
目前情况：过滤"gfwlist"、"chnroute"、"可信上游DNS"，遗漏"规则列表"、"Xray分流规则"
修复后：
- Dnsmasq负责过滤"chnroute"、"规则列表"、"Xray分流规则(部分)"
- ChinaDNS-NG负责过滤"gfwlist"、"可信上游DNS"
```