### PR TITLE
fix  get_version shell command

### DIFF
--- a/luci-app-passwall/luasrc/passwall/api.lua
+++ b/luci-app-passwall/luasrc/passwall/api.lua
@@ -938,7 +938,7 @@ function to_move(app_name,file)
 end
 
 function get_version()
-	return sys.exec("echo -n $(opkg info luci-app-passwall |grep 'Version'|awk '{print $2}')")
+	return sys.exec("echo -n $(opkg list-installed luci-app-passwall |awk '{print $3}')")
 end
 
 function to_check_self()


### PR DESCRIPTION
修复从opkg获取软件包版本号的错误。
从一开始写passwall自身版本检查的时候，这个命令就写错了，一直没发现，原来的命令可以把未安装的但是源里有的版本也列出来，有时候安装更新后，会显示出2个版本号。改为使用`opkg list-installed`获取已安装版本号。