### PR TITLE
luci: disable sniff_override_destination

### DIFF
--- a/luci-app-passwall/luasrc/model/cbi/passwall/client/other.lua
+++ b/luci-app-passwall/luasrc/model/cbi/passwall/client/other.lua
@@ -180,7 +180,7 @@ if has_singbox then
 	s.addremove = false
 
 	o = s:option(Flag, "sniff_override_destination", translate("Override the connection destination address"), translate("Override the connection destination address with the sniffed domain."))
-	o.default = 1
+	o.default = 0
 	o.rmempty = false
 
 	o = s:option(Value, "geoip_path", translate("Custom geoip Path"))

--- a/luci-app-passwall/root/etc/uci-defaults/luci-passwall
+++ b/luci-app-passwall/root/etc/uci-defaults/luci-passwall
@@ -61,7 +61,7 @@ sed -i "s#option tlsflow#option flow#g" /etc/config/passwall
 global_singbox=$(uci -q get passwall.@global_singbox[0])
 [ -z "${global_singbox}" ] && {
 	cfgid=$(uci add passwall global_singbox)
-	uci -q set passwall.${cfgid}.sniff_override_destination=1
+	uci -q set passwall.${cfgid}.sniff_override_destination=0
 	uci -q set passwall.${cfgid}.geoip_path="/tmp/singbox/geoip.db"
 	uci -q set passwall.${cfgid}.geoip_url="https://github.com/SagerNet/sing-geoip/releases/latest/download/geoip.db"
 	uci -q set passwall.${cfgid}.geosite_path="/tmp/singbox/geosite.db"

--- a/luci-app-passwall/root/usr/share/passwall/0_default_config
+++ b/luci-app-passwall/root/usr/share/passwall/0_default_config
@@ -44,7 +44,7 @@ config global_xray
 	option route_only '0'
 	
 config global_singbox
-	option sniff_override_destination '1'
+	option sniff_override_destination '0'
 	option geoip_path '/usr/share/singbox/geoip.db'
 	option geoip_url 'https://github.com/SagerNet/sing-geoip/releases/latest/download/geoip.db'
 	option geosite_path '/usr/share/singbox/geosite.db'


### PR DESCRIPTION
根据sing-box的内置dns处理流程，开启sniff之后，route_rule就已经可以匹配域名规则。
该选项其实是*ray时代的历史遗留问题，任何情况下（客户端&服务器端）都并不需要，也不推荐开启sniff_override_destination。
如果需要向服务器端传送域名，应该采用fake ip模式。
且开启sniff_override_destination可能会造成一些未知的问题，例如APN推送可能出现故障。
该选项应该默认设置为关闭，而不是开启。