### PR TITLE
feat: hysteria2 support verify tls pinSHA256

### DIFF
--- a/luci-app-passwall/luasrc/model/cbi/passwall/client/type/hysteria2.lua
+++ b/luci-app-passwall/luasrc/model/cbi/passwall/client/type/hysteria2.lua
@@ -44,6 +44,9 @@ o = s:option(Value, option_name("tls_serverName"), translate("Domain"))
 o = s:option(Flag, option_name("tls_allowInsecure"), translate("allowInsecure"), translate("Whether unsafe connections are allowed. When checked, Certificate validation will be skipped."))
 o.default = "0"
 
+o = s:option(Value, option_name("tls_pinSHA256"), translate("PinSHA256"),translate("Certificate fingerprint"))
+o.rewrite_option = o.option
+
 o = s:option(Value, option_name("up_mbps"), translate("Max upload Mbps"))
 o.rewrite_option = o.option
 

--- a/luci-app-passwall/luasrc/passwall/util_hysteria2.lua
+++ b/luci-app-passwall/luasrc/passwall/util_hysteria2.lua
@@ -77,7 +77,7 @@ function gen_config(var)
 		auth = node.hysteria2_auth_password,
 		tls = {
 			sni = node.tls_serverName,
-			insecure = (node.tls_allowInsecure == "1") and true or false
+			insecure = (node.tls_allowInsecure == "1") and true or false,
 			pinSHA256 = (node.tls_pinSHA256) and node.tls_pinSHA256 or nil,
 		},
 		quic = {

--- a/luci-app-passwall/luasrc/passwall/util_hysteria2.lua
+++ b/luci-app-passwall/luasrc/passwall/util_hysteria2.lua
@@ -78,7 +78,7 @@ function gen_config(var)
 		tls = {
 			sni = node.tls_serverName,
 			insecure = (node.tls_allowInsecure == "1") and true or false,
-			pinSHA256 = (node.tls_pinSHA256) and node.tls_pinSHA256 or nil,
+			pinSHA256 = (node.hysteria2_tls_pinSHA256) and node.hysteria2_tls_pinSHA256 or nil,
 		},
 		quic = {
 			initStreamReceiveWindow = (node.hysteria2_recv_window) and tonumber(node.hysteria2_recv_window) or nil,

--- a/luci-app-passwall/luasrc/passwall/util_hysteria2.lua
+++ b/luci-app-passwall/luasrc/passwall/util_hysteria2.lua
@@ -78,6 +78,7 @@ function gen_config(var)
 		tls = {
 			sni = node.tls_serverName,
 			insecure = (node.tls_allowInsecure == "1") and true or false
+			pinSHA256 = (node.tls_pinSHA256) and node.tls_pinSHA256 or nil,
 		},
 		quic = {
 			initStreamReceiveWindow = (node.hysteria2_recv_window) and tonumber(node.hysteria2_recv_window) or nil,

--- a/luci-app-passwall/po/zh-cn/passwall.po
+++ b/luci-app-passwall/po/zh-cn/passwall.po
@@ -514,6 +514,12 @@ msgstr "认证密码"
 msgid "Commands the client to use the BBR flow control algorithm"
 msgstr "命令客户端使用 BBR 流量控制算法"
 
+msgid "PinSHA256"
+msgstr "PinSHA256"
+
+msgid "Certificate fingerprint"
+msgstr "证书指纹"
+
 msgid "Max upload Mbps"
 msgstr "最大上行(Mbps)"
 


### PR DESCRIPTION
support using the pinSHA256 option to verify the server's certificate fingerprint.