### PR TITLE
luci: add sing-box Shadowsocks SIP003 plugin support

### DIFF
--- a/luci-app-passwall/luasrc/model/cbi/passwall/client/type/sing-box.lua
+++ b/luci-app-passwall/luasrc/model/cbi/passwall/client/type/sing-box.lua
@@ -612,4 +612,18 @@ if singbox_tags:find("with_utls") then
 	o:depends({ [option_name("shadowtls")] = true, [option_name("shadowtls_utls")] = true })
 end
 
+-- [[ SIP003 plugin ]]--
+o = s:option(Flag, option_name("plugin_enabled"), translate("plugin"))
+o.default = 0
+o:depends({ [option_name("protocol")] = "shadowsocks" })
+
+o = s:option(ListValue, option_name("plugin"), "SIP003 " .. translate("plugin"))
+o.default = "obfs-local"
+o:depends({ [option_name("plugin_enabled")] = true })
+o:value("obfs-local")
+o:value("v2ray-plugin")
+
+o = s:option(Value, option_name("plugin_opts"), translate("opts"))
+o:depends({ [option_name("plugin_enabled")] = true })
+
 api.luci_types(arg[1], m, s, type_name, option_prefix)

--- a/luci-app-passwall/luasrc/passwall/util_sing-box.lua
+++ b/luci-app-passwall/luasrc/passwall/util_sing-box.lua
@@ -201,8 +201,8 @@ function gen_outbound(flag, node, tag, proxy_table)
 			protocol_table = {
 				method = node.method or nil,
 				password = node.password or "",
-				plugin = node.plugin and nil,
-				plugin_opts = node.plugin_opts and nil,
+				plugin = (node.plugin_enabled and node.plugin) or nil,
+				plugin_opts = (node.plugin_enabled and node.plugin_opts) or nil,
 				udp_over_tcp = node.uot == "1" and {
 					enabled = true,
 					version = 2


### PR DESCRIPTION
According to [sing-box manual](https://sing-box.sagernet.org/configuration/outbound/shadowsocks/#plugin), the built-in shadowsocks protocol of sing-box supports two SIP003 plugins.