### PR TITLE
luci: add Xiaomi Community to Proxy

### DIFF
--- a/luci-app-passwall/root/usr/share/passwall/rules/proxy_host
+++ b/luci-app-passwall/root/usr/share/passwall/rules/proxy_host
@@ -1,6 +1,7 @@
 bing.com
 sspanel.net
 v2ex.com
+c.mi.com
 
 #google
 googleapis.cn


### PR DESCRIPTION
The domain c.mi.com for the international version of the Xiaomi community is blocked from resolving in mainland China, so it needs to be added to the proxy list.