### PR TITLE
luci: Remove unzip and add dnsmasq-full for depends

### DIFF
--- a/luci-app-passwall/Makefile
+++ b/luci-app-passwall/Makefile
@@ -33,8 +33,9 @@ PKG_CONFIG_DEPENDS:= \
 LUCI_TITLE:=LuCI support for PassWall
 LUCI_PKGARCH:=all
 LUCI_DEPENDS:=+coreutils +coreutils-base64 +coreutils-nohup +curl \
-	+chinadns-ng +dns2socks +dns2tcp +ip-full +libuci-lua +lua +luci-compat +luci-lib-jsonc \
-	+microsocks +resolveip +tcping +unzip
+	+chinadns-ng +dns2socks +dns2tcp +dnsmasq-full +ip-full \
+	+libuci-lua +lua +luci-compat +luci-lib-jsonc \
+	+microsocks +resolveip +tcping
 
 define Package/$(PKG_NAME)/config
 menu "Configuration"
@@ -42,7 +43,6 @@ menu "Configuration"
 
 config PACKAGE_$(PKG_NAME)_Iptables_Transparent_Proxy
 	bool "Iptables Transparent Proxy"
-	select PACKAGE_dnsmasq-full
 	select PACKAGE_ipset
 	select PACKAGE_ipt2socks
 	select PACKAGE_iptables
@@ -56,7 +56,6 @@ config PACKAGE_$(PKG_NAME)_Iptables_Transparent_Proxy
 
 config PACKAGE_$(PKG_NAME)_Nftables_Transparent_Proxy
 	bool "Nftables Transparent Proxy"
-	select PACKAGE_dnsmasq-full
 	select PACKAGE_ipt2socks
 	select PACKAGE_nftables
 	select PACKAGE_kmod-nft-socket
@@ -149,6 +148,7 @@ config PACKAGE_$(PKG_NAME)_INCLUDE_V2ray_Plugin
 config PACKAGE_$(PKG_NAME)_INCLUDE_Xray
 	bool "Include Xray"
 	select PACKAGE_xray-core
+	select PACKAGE_unzip
 	default y if aarch64||arm||i386||x86_64
 
 config PACKAGE_$(PKG_NAME)_INCLUDE_Xray_Plugin


### PR DESCRIPTION
目前只有在 passwall 页面升级 xray-core 时需要 unzip，xray-core 已经被移出依赖，所以也没必要依赖 unzip 了，改为与 xray-core 一起被默认选中。（若未安装 unzip，在 passwall 页面升级 xray-core 时，passwall 也会在日志中提示缺少 unzip）

iptables 和 nftables 都需要 dnsmasq-full，设置为依赖