### PR TITLE
luci: hotplug.d: output restart log as syslog

### DIFF
--- a/luci-app-passwall/root/etc/hotplug.d/iface/98-passwall
+++ b/luci-app-passwall/root/etc/hotplug.d/iface/98-passwall
@@ -16,7 +16,7 @@
 		echo $$ > ${LOCK_FILE}
 		
 		/etc/init.d/passwall restart >/dev/null 2>&1 &
-		echo "passwall: restart when $INTERFACE ifup" > /dev/kmsg
+		logger -p notice -t network -s "passwall: restart when $INTERFACE ifup"
 		
 		rm -rf ${LOCK_FILE}
 	}


### PR DESCRIPTION
* As an application layer service, it should not appear on the kernel log