### PR TITLE
Expanded comment regex pattern to include lines starting with '#'

### DIFF
--- a/luci-app-passwall/root/usr/share/passwall/rule_update.lua
+++ b/luci-app-passwall/root/usr/share/passwall/rule_update.lua
@@ -19,7 +19,7 @@ local geoip_update = 0
 local geosite_update = 0
 
 -- match comments/title/whitelist/ip address/excluded_domain
-local comment_pattern = "^[!\\[@]+"
+local comment_pattern = "^[#!\\[@]+"
 local ip_pattern = "^%d+%.%d+%.%d+%.%d+"
 local ip4_ipset_pattern = "^%d+%.%d+%.%d+%.%d+[%/][%d]+$"
 local ip6_ipset_pattern = ":-[%x]+%:+[%x]-[%/][%d]+$"


### PR DESCRIPTION
Some of the files such as those from the dnsmasq-china-list repositories use a '#' to comment out lines. Without this change comment lines will not be excluded and their contents mistakingly added to the corresponding list.