### PR TITLE
luci: adapt to chinadns-ng updates

### DIFF
--- a/luci-app-passwall/root/usr/share/passwall/app.sh
+++ b/luci-app-passwall/root/usr/share/passwall/app.sh
@@ -1256,7 +1256,7 @@ start_dns() {
 
 	[ "$CHINADNS_NG" = "1" ] && [ -n "$(first_type chinadns-ng)" ] && ([ "${CHN_LIST}" = "direct" ] || [ "${USE_GFW_LIST}" = "1" ]) && {
 		[ "$FILTER_PROXY_IPV6" = "1" ] && {
-			local _no_ipv6_rules="gt"
+			local _no_ipv6_rules="tag:gfw"
 			FILTER_PROXY_IPV6=0
 		}
 		local china_ng_listen_port=$(expr $dns_listen_port + 1)
@@ -1419,7 +1419,7 @@ acl_app() {
 
 							[ "$chinadns_ng" = "1" ] && [ -n "$(first_type chinadns-ng)" ] && ([ "${chn_list}" = "direct" ] || [ "${use_gfw_list}" = "1" ]) && {
 								[ "$filter_proxy_ipv6" = "1" ] && {
-									local _no_ipv6_rules="gt"
+									local _no_ipv6_rules="tag:gfw"
 									filter_proxy_ipv6=0
 								}
 								chinadns_port=$(expr $chinadns_port + 1)


### PR DESCRIPTION
适配2024.04.13版本ChinaDNS-NG的 --no-ipv6 规则修改，修复使用ChinaDNS-NG时勾选“过滤代理域名 IPv6” 会导致断网。
https://github.com/xiaorouji/openwrt-passwall/issues/3123