### PR TITLE
luci: compatible with all chinadns-ng versions

### DIFF
--- a/luci-app-passwall/root/usr/share/passwall/app.sh
+++ b/luci-app-passwall/root/usr/share/passwall/app.sh
@@ -1256,7 +1256,12 @@ start_dns() {
 
 	[ "$CHINADNS_NG" = "1" ] && [ -n "$(first_type chinadns-ng)" ] && ([ "${CHN_LIST}" = "direct" ] || [ "${USE_GFW_LIST}" = "1" ]) && {
 		[ "$FILTER_PROXY_IPV6" = "1" ] && {
-			local _no_ipv6_rules="tag:gfw"
+			chinadns_ng_date=$(chinadns-ng -V | grep -i "ChinaDNS-NG " | awk '{print $2}' | awk 'BEGIN{FS=".";OFS="-"};{print $1,$2,$3}')
+			if [ $(date -d "$chinadns_ng_date" +%s) -ge $(date -d "2024-04-13" +%s) ]; then
+				local _no_ipv6_rules="tag:gfw"
+			else
+				local _no_ipv6_rules="gt"
+			fi
 			FILTER_PROXY_IPV6=0
 		}
 		local china_ng_listen_port=$(expr $dns_listen_port + 1)
@@ -1419,7 +1424,12 @@ acl_app() {
 
 							[ "$chinadns_ng" = "1" ] && [ -n "$(first_type chinadns-ng)" ] && ([ "${chn_list}" = "direct" ] || [ "${use_gfw_list}" = "1" ]) && {
 								[ "$filter_proxy_ipv6" = "1" ] && {
-									local _no_ipv6_rules="tag:gfw"
+									chinadns_ng_date=$(chinadns-ng -V | grep -i "ChinaDNS-NG " | awk '{print $2}' | awk 'BEGIN{FS=".";OFS="-"};{print $1,$2,$3}')
+									if [ $(date -d "$chinadns_ng_date" +%s) -ge $(date -d "2024-04-13" +%s) ]; then
+										local _no_ipv6_rules="tag:gfw"
+									else
+										local _no_ipv6_rules="gt"
+									fi
 									filter_proxy_ipv6=0
 								}
 								chinadns_port=$(expr $chinadns_port + 1)


### PR DESCRIPTION
适配新老版本ChinaDNS-NG的 --no-ipv6 规则，增加兼容性。