### PR TITLE
luci: check connect optimization

### DIFF
--- a/luci-app-passwall/luasrc/controller/passwall.lua
+++ b/luci-app-passwall/luasrc/controller/passwall.lua
@@ -250,6 +250,15 @@ function connect_status()
 	local e = {}
 	e.use_time = ""
 	local url = luci.http.formvalue("url")
+	local is_baidu = string.find(url, "baidu")
+	local pw_switch = uci:get(appname, "@global[0]", "enabled")
+	local chn_list = uci:get(appname, "@global[0]", "chn_list")
+	local socks_port = uci:get(appname, "@global[0]", "tcp_node_socks_port")
+	if pw_switch ~= 0 then
+		if is_baidu == nil or chn_list ~= "proxy" then
+			url = "--socks5 127.0.0.1:" .. socks_port .. " " .. url
+		end
+	end
 	local result = luci.sys.exec('curl --connect-timeout 3 -o /dev/null -I -sk -w "%{http_code}:%{time_appconnect}" ' .. url)
 	local code = tonumber(luci.sys.exec("echo -n '" .. result .. "' | awk -F ':' '{print $1}'") or "0")
 	if code ~= 0 then

--- a/luci-app-passwall/luasrc/controller/passwall.lua
+++ b/luci-app-passwall/luasrc/controller/passwall.lua
@@ -255,8 +255,14 @@ function connect_status()
 	local chn_list = uci:get(appname, "@global[0]", "chn_list")
 	local socks_port = uci:get(appname, "@global[0]", "tcp_node_socks_port")
 	if pw_switch ~= 0 then
-		if is_baidu == nil or chn_list ~= "proxy" then
-			url = "--socks5 127.0.0.1:" .. socks_port .. " " .. url
+		if chn_list == "proxy" then
+			if is_baidu ~= nil then
+				url = "--socks5 127.0.0.1:" .. socks_port .. " " .. url
+			end
+		else
+			if is_baidu == nil then
+				url = "--socks5 127.0.0.1:" .. socks_port .. " " .. url
+			end
 		end
 	end
 	local result = luci.sys.exec('curl --connect-timeout 3 -o /dev/null -I -sk -w "%{http_code}:%{time_appconnect}" ' .. url)


### PR DESCRIPTION
优化首页网站连接测试，为避免用户关闭了“路由器本机代理”导致首页测试google、github和Instagram测试失败，而在特定情况下为curl加上socks5代理，思路如下：
1.当启用PW时，检测是否是测试百度网站，如果是则百度采用直连测试，其他网站采用代理测试。
2.当启用PW时，检测“中国列表”是否是代理模式，如果“中国列表”为代理模式说明用户在国外使用（回国模式），则百度采用代理其他网站采用直连测试（虽然百度在外网不需要代理也可以访问，但为了测试节点连通性，所以在“回国模式”下给测试百度加入代理）。
3.当关闭PW时，所有网站均为直连测试。