### PR TITLE
luci: auto update rules optimization

### DIFF
--- a/luci-app-passwall/luasrc/model/cbi/passwall/client/node_subscribe_config.lua
+++ b/luci-app-passwall/luasrc/model/cbi/passwall/client/node_subscribe_config.lua
@@ -131,19 +131,41 @@ o = s:option(Flag, "auto_update", translate("Enable auto update subscribe"))
 o.default = 0
 o.rmempty = false
 
----- Week update rules
-o = s:option(ListValue, "week_update", translate("Week update rules"))
+---- Week Update
+o = s:option(ListValue, "week_update", translate("Update Mode"))
+o:value(8, translate("Loop Mode"))
 o:value(7, translate("Every day"))
-for e = 1, 6 do o:value(e, translate("Week") .. e) end
-o:value(0, translate("Week") .. translate("day"))
-o.default = 0
+o:value(1, translate("Every Monday"))
+o:value(2, translate("Every Tuesday"))
+o:value(3, translate("Every Wednesday"))
+o:value(4, translate("Every Thursday"))
+o:value(5, translate("Every Friday"))
+o:value(6, translate("Every Saturday"))
+o:value(0, translate("Every Sunday"))
+o.default = 7
 o:depends("auto_update", true)
+o.rmempty = true
 
----- Day update rules
-o = s:option(ListValue, "time_update", translate("Day update rules"))
-for e = 0, 23 do o:value(e, e .. translate("oclock")) end
+---- Time Update
+o = s:option(ListValue, "time_update", translate("Update Time(every day)"))
+for t = 0, 23 do o:value(t, t .. ":00") end
 o.default = 0
-o:depends("auto_update", true)
+o:depends("week_update", "0")
+o:depends("week_update", "1")
+o:depends("week_update", "2")
+o:depends("week_update", "3")
+o:depends("week_update", "4")
+o:depends("week_update", "5")
+o:depends("week_update", "6")
+o:depends("week_update", "7")
+o.rmempty = true
+
+---- Interval Update
+o = s:option(ListValue, "interval_update", translate("Update Interval(hour)"))
+for t = 1, 24 do o:value(t, t .. " " .. translate("hour")) end
+o.default = 2
+o:depends("week_update", "8")
+o.rmempty = true
 
 o = s:option(Value, "user_agent", translate("User-Agent"))
 o.default = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36 Edg/122.0.0.0"

--- a/luci-app-passwall/luasrc/model/cbi/passwall/client/rule.lua
+++ b/luci-app-passwall/luasrc/model/cbi/passwall/client/rule.lua
@@ -50,18 +50,40 @@ o.default = 0
 o.rmempty = false
 
 ---- Week Update
-o = s:option(ListValue, "week_update", translate("Week update rules"))
+o = s:option(ListValue, "week_update", translate("Update Mode"))
+o:value(8, translate("Loop Mode"))
 o:value(7, translate("Every day"))
-for e = 1, 6 do o:value(e, translate("Week") .. e) end
-o:value(0, translate("Week") .. translate("day"))
-o.default = 0
+o:value(1, translate("Every Monday"))
+o:value(2, translate("Every Tuesday"))
+o:value(3, translate("Every Wednesday"))
+o:value(4, translate("Every Thursday"))
+o:value(5, translate("Every Friday"))
+o:value(6, translate("Every Saturday"))
+o:value(0, translate("Every Sunday"))
+o.default = 7
 o:depends("auto_update", true)
+o.rmempty = true
 
 ---- Time Update
-o = s:option(ListValue, "time_update", translate("Day update rules"))
-for e = 0, 23 do o:value(e, e .. translate("oclock")) end
+o = s:option(ListValue, "time_update", translate("Update Time(every day)"))
+for t = 0, 23 do o:value(t, t .. ":00") end
 o.default = 0
-o:depends("auto_update", true)
+o:depends("week_update", "0")
+o:depends("week_update", "1")
+o:depends("week_update", "2")
+o:depends("week_update", "3")
+o:depends("week_update", "4")
+o:depends("week_update", "5")
+o:depends("week_update", "6")
+o:depends("week_update", "7")
+o.rmempty = true
+
+---- Interval Update
+o = s:option(ListValue, "interval_update", translate("Update Interval(hour)"))
+for t = 1, 24 do o:value(t, t .. " " .. translate("hour")) end
+o.default = 2
+o:depends("week_update", "8")
+o.rmempty = true
 
 if has_xray or has_singbox then
 	o = s:option(Value, "v2ray_location_asset", translate("Location of V2ray/Xray asset"), translate("This variable specifies a directory where geoip.dat and geosite.dat files are."))

--- a/luci-app-passwall/po/zh-cn/passwall.po
+++ b/luci-app-passwall/po/zh-cn/passwall.po
@@ -838,23 +838,44 @@ msgstr "规则版本"
 msgid "Enable auto update rules"
 msgstr "开启自动更新规则"
 
-msgid "Week update rules"
-msgstr "更新时间星期"
+msgid "Update Time(every day)"
+msgstr "更新时间(每天)"
 
-msgid "Day update rules"
-msgstr "更新时间小时"
+msgid "Update Interval(hour)"
+msgstr "更新间隔(小时)"
+
+msgid "Update Mode"
+msgstr "更新模式"
+
+msgid "Loop Mode"
+msgstr "循环"
 
 msgid "Every day"
 msgstr "每天"
 
-msgid "day"
-msgstr "日"
+msgid "Every Monday"
+msgstr "每周一"
 
-msgid "Week"
-msgstr "周"
+msgid "Every Tuesday"
+msgstr "每周二"
 
-msgid "oclock"
-msgstr "点"
+msgid "Every Wednesday"
+msgstr "每周三"
+
+msgid "Every Thursday"
+msgstr "每周四"
+
+msgid "Every Friday"
+msgstr "每周五"
+
+msgid "Every Saturday"
+msgstr "每周六"
+
+msgid "Every Sunday"
+msgstr "每周日"
+
+msgid "hour"
+msgstr "小时"
 
 msgid "Location of V2ray/Xray asset"
 msgstr "V2ray/Xray 资源文件目录"

--- a/luci-app-passwall/root/usr/share/passwall/app.sh
+++ b/luci-app-passwall/root/usr/share/passwall/app.sh
@@ -1178,9 +1178,11 @@ start_crontab() {
 	autoupdate=$(config_t_get global_rules auto_update)
 	weekupdate=$(config_t_get global_rules week_update)
 	dayupdate=$(config_t_get global_rules time_update)
+	hourupdate=$(config_t_get global_rules interval_update)
 	if [ "$autoupdate" = "1" ]; then
 		local t="0 $dayupdate * * $weekupdate"
 		[ "$weekupdate" = "7" ] && t="0 $dayupdate * * *"
+		[ "$weekupdate" = "8" ] && t="0 */$hourupdate * * *"
 		echo "$t lua $APP_PATH/rule_update.lua log > /dev/null 2>&1 &" >>/etc/crontabs/root
 		echolog "配置定时任务：自动更新规则。"
 	fi
@@ -1193,7 +1195,8 @@ start_crontab() {
 			remark=$(config_n_get $item remark)
 			week_update=$(config_n_get $item week_update)
 			time_update=$(config_n_get $item time_update)
-			echo "$cfgid" >> $TMP_SUB_PATH/${week_update}_${time_update}
+			hour_update=$(config_n_get $item interval_update)
+			echo "$cfgid" >> $TMP_SUB_PATH/${week_update}_${time_update}_${hour_update}
 			echolog "配置定时任务：自动更新【$remark】订阅。"
 		fi
 	done
@@ -1202,8 +1205,10 @@ start_crontab() {
 		for name in $(ls ${TMP_SUB_PATH}); do
 			week_update=$(echo $name | awk -F '_' '{print $1}')
 			time_update=$(echo $name | awk -F '_' '{print $2}')
+			hour_update=$(echo $name | awk -F '_' '{print $3}')
 			local t="0 $time_update * * $week_update"
 			[ "$week_update" = "7" ] && t="0 $time_update * * *"
+			[ "$week_update" = "8" ] && t="0 */$hour_update * * *"
 			cfgids=$(echo -n $(cat ${TMP_SUB_PATH}/${name}) | sed 's# #,#g')
 			echo "$t lua $APP_PATH/subscribe.lua start $cfgids > /dev/null 2>&1 &" >>/etc/crontabs/root
 		done


### PR DESCRIPTION
根据 https://github.com/xiaorouji/openwrt-passwall/issues/3192 的建议：

1.新增循环更新模式，可设置间隔1-24小时循环更新。
2.优化原更新设置选项中的一些用词和翻译，读起来可能更舒服些。

![1](https://github.com/xiaorouji/openwrt-passwall/assets/86697442/33e9ec0c-497c-41a3-82a1-60dad1fc9d78)
————————————————————
![2](https://github.com/xiaorouji/openwrt-passwall/assets/86697442/80145ecc-1541-4724-ace6-dd88659f3c45)
————————————————————
![3](https://github.com/xiaorouji/openwrt-passwall/assets/86697442/3596fdf5-7371-4fcd-be68-06ca168732a9)
