### PR TITLE
luci: auto update rules optimization

### DIFF
--- a/luci-app-passwall/luasrc/model/cbi/passwall/client/node_subscribe_config.lua
+++ b/luci-app-passwall/luasrc/model/cbi/passwall/client/node_subscribe_config.lua
@@ -131,19 +131,41 @@ o = s:option(Flag, "auto_update", translate("Enable auto update subscribe"))
 o.default = 0
 o.rmempty = false
 
----- Week update rules
-o = s:option(ListValue, "week_update", translate("Week update rules"))
+---- Week Update
+o = s:option(ListValue, "week_update", translate("Update Mode"))
+o:value(8, translate("Loop Mode"))
 o:value(7, translate("Every day"))
-for e = 1, 6 do o:value(e, translate("Week") .. e) end
-o:value(0, translate("Week") .. translate("day"))
-o.default = 0
+o:value(1, translate("Every Monday"))
+o:value(2, translate("Every Tuesday"))
+o:value(3, translate("Every Wednesday"))
+o:value(4, translate("Every Thursday"))
+o:value(5, translate("Every Friday"))
+o:value(6, translate("Every Saturday"))
+o:value(0, translate("Every Sunday"))
+o.default = 7
 o:depends("auto_update", true)
+o.rmempty = true
 
----- Day update rules
-o = s:option(ListValue, "time_update", translate("Day update rules"))
-for e = 0, 23 do o:value(e, e .. translate("oclock")) end
+---- Time Update
+o = s:option(ListValue, "time_update", translate("Update Time(every day)"))
+for t = 0, 23 do o:value(t, t .. ":00") end
 o.default = 0
-o:depends("auto_update", true)
+o:depends("week_update", "0")
+o:depends("week_update", "1")
+o:depends("week_update", "2")
+o:depends("week_update", "3")
+o:depends("week_update", "4")
+o:depends("week_update", "5")
+o:depends("week_update", "6")
+o:depends("week_update", "7")
+o.rmempty = true
+
+---- Interval Update
+o = s:option(ListValue, "interval_update", translate("Update Interval(hour)"))
+for t = 1, 24 do o:value(t, t .. " " .. translate("hour")) end
+o.default = 2
+o:depends("week_update", "8")
+o.rmempty = true
 
 o = s:option(Value, "user_agent", translate("User-Agent"))
 o.default = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36 Edg/122.0.0.0"

--- a/luci-app-passwall/luasrc/model/cbi/passwall/client/node_subscribe_config.lua
+++ b/luci-app-passwall/luasrc/model/cbi/passwall/client/node_subscribe_config.lua
@@ -162,7 +162,7 @@ o.rmempty = true
 
 ---- Interval Update
 o = s:option(ListValue, "interval_update", translate("Update Interval(hour)"))
-for t = 1, 24 do o:value(t, t .. " " .. translate("hour")) end
+for t = 1, 23 do o:value(t, t .. " " .. translate("hour")) end
 o.default = 2
 o:depends("week_update", "8")
 o.rmempty = true

--- a/luci-app-passwall/luasrc/model/cbi/passwall/client/rule.lua
+++ b/luci-app-passwall/luasrc/model/cbi/passwall/client/rule.lua
@@ -80,7 +80,7 @@ o.rmempty = true
 
 ---- Interval Update
 o = s:option(ListValue, "interval_update", translate("Update Interval(hour)"))
-for t = 1, 24 do o:value(t, t .. " " .. translate("hour")) end
+for t = 1, 23 do o:value(t, t .. " " .. translate("hour")) end
 o.default = 2
 o:depends("week_update", "8")
 o.rmempty = true

--- a/luci-app-passwall/luasrc/model/cbi/passwall/client/rule.lua
+++ b/luci-app-passwall/luasrc/model/cbi/passwall/client/rule.lua
@@ -50,18 +50,40 @@ o.default = 0
 o.rmempty = false
 
 ---- Week Update
-o = s:option(ListValue, "week_update", translate("Week update rules"))
+o = s:option(ListValue, "week_update", translate("Update Mode"))
+o:value(8, translate("Loop Mode"))
 o:value(7, translate("Every day"))
-for e = 1, 6 do o:value(e, translate("Week") .. e) end
-o:value(0, translate("Week") .. translate("day"))
-o.default = 0
+o:value(1, translate("Every Monday"))
+o:value(2, translate("Every Tuesday"))
+o:value(3, translate("Every Wednesday"))
+o:value(4, translate("Every Thursday"))
+o:value(5, translate("Every Friday"))
+o:value(6, translate("Every Saturday"))
+o:value(0, translate("Every Sunday"))
+o.default = 7
 o:depends("auto_update", true)
+o.rmempty = true
 
 ---- Time Update
-o = s:option(ListValue, "time_update", translate("Day update rules"))
-for e = 0, 23 do o:value(e, e .. translate("oclock")) end
+o = s:option(ListValue, "time_update", translate("Update Time(every day)"))
+for t = 0, 23 do o:value(t, t .. ":00") end
 o.default = 0
-o:depends("auto_update", true)
+o:depends("week_update", "0")
+o:depends("week_update", "1")
+o:depends("week_update", "2")
+o:depends("week_update", "3")
+o:depends("week_update", "4")
+o:depends("week_update", "5")
+o:depends("week_update", "6")
+o:depends("week_update", "7")
+o.rmempty = true
+
+---- Interval Update
+o = s:option(ListValue, "interval_update", translate("Update Interval(hour)"))
+for t = 1, 24 do o:value(t, t .. " " .. translate("hour")) end
+o.default = 2
+o:depends("week_update", "8")
+o.rmempty = true
 
 if has_xray or has_singbox then
 	o = s:option(Value, "v2ray_location_asset", translate("Location of V2ray/Xray asset"), translate("This variable specifies a directory where geoip.dat and geosite.dat files are."))

--- a/luci-app-passwall/po/zh-cn/passwall.po
+++ b/luci-app-passwall/po/zh-cn/passwall.po
@@ -838,23 +838,44 @@ msgstr "规则版本"
 msgid "Enable auto update rules"
 msgstr "开启自动更新规则"
 
-msgid "Week update rules"
-msgstr "更新时间星期"
+msgid "Update Time(every day)"
+msgstr "更新时间(每天)"
 
-msgid "Day update rules"
-msgstr "更新时间小时"
+msgid "Update Interval(hour)"
+msgstr "更新间隔(小时)"
+
+msgid "Update Mode"
+msgstr "更新模式"
+
+msgid "Loop Mode"
+msgstr "循环"
 
 msgid "Every day"
 msgstr "每天"
 
-msgid "day"
-msgstr "日"
+msgid "Every Monday"
+msgstr "每周一"
 
-msgid "Week"
-msgstr "周"
+msgid "Every Tuesday"
+msgstr "每周二"
 
-msgid "oclock"
-msgstr "点"
+msgid "Every Wednesday"
+msgstr "每周三"
+
+msgid "Every Thursday"
+msgstr "每周四"
+
+msgid "Every Friday"
+msgstr "每周五"
+
+msgid "Every Saturday"
+msgstr "每周六"
+
+msgid "Every Sunday"
+msgstr "每周日"
+
+msgid "hour"
+msgstr "小时"
 
 msgid "Location of V2ray/Xray asset"
 msgstr "V2ray/Xray 资源文件目录"

--- a/luci-app-passwall/root/usr/share/passwall/app.sh
+++ b/luci-app-passwall/root/usr/share/passwall/app.sh
@@ -1182,7 +1182,7 @@ start_crontab() {
 	if [ "$autoupdate" = "1" ]; then
 		local t="0 $dayupdate * * $weekupdate"
 		[ "$weekupdate" = "7" ] && t="0 $dayupdate * * *"
-		[ "$weekupdate" = "8" ] && t="0 */$hourupdate * * *"
+		[ "$weekupdate" = "8" ] && t="*/$(($hourupdate*60)) * * * *"
 		echo "$t lua $APP_PATH/rule_update.lua log > /dev/null 2>&1 &" >>/etc/crontabs/root
 		echolog "配置定时任务：自动更新规则。"
 	fi
@@ -1208,7 +1208,7 @@ start_crontab() {
 			hour_update=$(echo $name | awk -F '_' '{print $3}')
 			local t="0 $time_update * * $week_update"
 			[ "$week_update" = "7" ] && t="0 $time_update * * *"
-			[ "$week_update" = "8" ] && t="0 */$hour_update * * *"
+			[ "$week_update" = "8" ] && t="*/$(($hour_update*60)) * * * *"
 			cfgids=$(echo -n $(cat ${TMP_SUB_PATH}/${name}) | sed 's# #,#g')
 			echo "$t lua $APP_PATH/subscribe.lua start $cfgids > /dev/null 2>&1 &" >>/etc/crontabs/root
 		done

--- a/luci-app-passwall/root/usr/share/passwall/app.sh
+++ b/luci-app-passwall/root/usr/share/passwall/app.sh
@@ -1178,9 +1178,11 @@ start_crontab() {
 	autoupdate=$(config_t_get global_rules auto_update)
 	weekupdate=$(config_t_get global_rules week_update)
 	dayupdate=$(config_t_get global_rules time_update)
+	hourupdate=$(config_t_get global_rules interval_update)
 	if [ "$autoupdate" = "1" ]; then
 		local t="0 $dayupdate * * $weekupdate"
 		[ "$weekupdate" = "7" ] && t="0 $dayupdate * * *"
+		[ "$weekupdate" = "8" ] && t="0 */$hourupdate * * *"
 		echo "$t lua $APP_PATH/rule_update.lua log > /dev/null 2>&1 &" >>/etc/crontabs/root
 		echolog "配置定时任务：自动更新规则。"
 	fi
@@ -1193,7 +1195,8 @@ start_crontab() {
 			remark=$(config_n_get $item remark)
 			week_update=$(config_n_get $item week_update)
 			time_update=$(config_n_get $item time_update)
-			echo "$cfgid" >> $TMP_SUB_PATH/${week_update}_${time_update}
+			hour_update=$(config_n_get $item interval_update)
+			echo "$cfgid" >> $TMP_SUB_PATH/${week_update}_${time_update}_${hour_update}
 			echolog "配置定时任务：自动更新【$remark】订阅。"
 		fi
 	done
@@ -1202,8 +1205,10 @@ start_crontab() {
 		for name in $(ls ${TMP_SUB_PATH}); do
 			week_update=$(echo $name | awk -F '_' '{print $1}')
 			time_update=$(echo $name | awk -F '_' '{print $2}')
+			hour_update=$(echo $name | awk -F '_' '{print $3}')
 			local t="0 $time_update * * $week_update"
 			[ "$week_update" = "7" ] && t="0 $time_update * * *"
+			[ "$week_update" = "8" ] && t="0 */$hour_update * * *"
 			cfgids=$(echo -n $(cat ${TMP_SUB_PATH}/${name}) | sed 's# #,#g')
 			echo "$t lua $APP_PATH/subscribe.lua start $cfgids > /dev/null 2>&1 &" >>/etc/crontabs/root
 		done

--- a/luci-app-passwall/root/usr/share/passwall/rule_update.lua
+++ b/luci-app-passwall/root/usr/share/passwall/rule_update.lua
@@ -8,6 +8,8 @@ local jsonc = require "luci.jsonc"
 local name = 'passwall'
 local api = require ("luci.passwall.api")
 local arg1 = arg[1]
+local arg2 = arg[2]
+local arg3 = arg[3]
 
 local rule_path = "/usr/share/" .. name .. "/rules"
 local reboot = 0
@@ -34,6 +36,10 @@ local geoip_api =  "https://api.github.com/repos/Loyalsoldier/v2ray-rules-dat/re
 local geosite_api =  "https://api.github.com/repos/Loyalsoldier/v2ray-rules-dat/releases/latest"
 local asset_location = ucic:get_first(name, 'global_rules', "v2ray_location_asset", "/usr/share/v2ray/")
 local use_nft = ucic:get(name, "@global_forwarding[0]", "use_nft") or "0"
+
+if arg3 == "cron" then
+	arg2 = nil
+end
 
 local log = function(...)
 	if arg1 then
@@ -369,8 +375,8 @@ local function fetch_geosite()
 	return 0
 end
 
-if arg[2] then
-	string.gsub(arg[2], '[^' .. "," .. ']+', function(w)
+if arg2 then
+	string.gsub(arg2, '[^' .. "," .. ']+', function(w)
 		if w == "gfwlist" then
 			gfwlist_update = 1
 		end
@@ -459,6 +465,15 @@ ucic:save(name)
 luci.sys.call("uci commit " .. name)
 
 if reboot == 1 then
+	if arg3 == "cron" then
+		local f = io.open("/var/lock/passwall.lock", "r")
+		if f == nil then
+			luci.sys.call("touch /var/lock/passwall_cron.lock")
+		else
+			f:close()
+		end
+	end
+
 	log("重启服务，应用新的规则。")
 	if use_nft == "1" then
 		luci.sys.call("sh /usr/share/" .. name .. "/nftables.sh flush_nftset_reload > /dev/null 2>&1 &")

--- a/luci-app-passwall/root/usr/share/passwall/subscribe.lua
+++ b/luci-app-passwall/root/usr/share/passwall/subscribe.lua
@@ -1164,6 +1164,16 @@ local function update_node(manual)
 
 		uci:commit(appname)
 	end
+
+	if arg[3] == "cron" then
+		local f = io.open("/var/lock/passwall.lock", "r")
+		if f == nil then
+			luci.sys.call("touch /var/lock/passwall_cron.lock")
+		else
+			f:close()
+		end
+	end
+
 	luci.sys.call("/etc/init.d/" .. appname .. " restart > /dev/null 2>&1 &")
 end
 


### PR DESCRIPTION
1.新增循环更新模式，可设置间隔1-23小时循环更新。
2.优化原更新设置选项中的一些用词和翻译，读起来可能更舒服些。
3.修改从计划任务执行“更新订阅”或“更新规则”后重启PW服务时不对crontab进行操作，避免cron重计时。

已知问题：因cron天生缺陷，在设置间隔N小时更新的策略后，系统运行至第1个整点将触发1次计划任务，当系统运行到凌晨0点两天交接处也将触发1次计划任务。

代码已在我的路由上运行通过，请各位大佬审核，看是否进行合并。以下是界面：

![1](https://github.com/xiaorouji/openwrt-passwall/assets/86697442/a6c4a236-51bd-498c-8f28-d026aee1b6c8)
————————————
![2](https://github.com/xiaorouji/openwrt-passwall/assets/86697442/2685b2d3-6ab4-4f7c-9cc4-514b0d9baf95)
————————————
![3](https://github.com/xiaorouji/openwrt-passwall/assets/86697442/bbf0af26-07c9-429a-8213-3cddcbe57c23)

