### PR TITLE
luci: check connect logic optimization

### DIFF
--- a/luci-app-passwall/luasrc/controller/passwall.lua
+++ b/luci-app-passwall/luasrc/controller/passwall.lua
@@ -250,19 +250,17 @@ function connect_status()
 	local e = {}
 	e.use_time = ""
 	local url = luci.http.formvalue("url")
-	local is_baidu = string.find(url, "baidu")
-	local pw_switch = uci:get(appname, "@global[0]", "enabled")
+	local baidu = string.find(url, "baidu")
+	local enabled = uci:get(appname, "@global[0]", "enabled")
 	local chn_list = uci:get(appname, "@global[0]", "chn_list")
+	local gfw_list = uci:get(appname, "@global[0]", "use_gfw_list") or "1"
+	local proxy_mode = uci:get(appname, "@global[0]", "tcp_proxy_mode")
 	local socks_port = uci:get(appname, "@global[0]", "tcp_node_socks_port")
-	if pw_switch ~= 0 then
-		if chn_list == "proxy" then
-			if is_baidu ~= nil then
-				url = "--socks5 127.0.0.1:" .. socks_port .. " " .. url
-			end
-		else
-			if is_baidu == nil then
-				url = "--socks5 127.0.0.1:" .. socks_port .. " " .. url
-			end
+	if enabled ~= 0 then
+		if (chn_list == "proxy" and gfw_list == 0 and proxy_mode ~= "proxy" and baidu ~= nil) or (chn_list == 0 and gfw_list == 0 and proxy_mode == "proxy") then
+			url = "--socks5 127.0.0.1:" .. socks_port .. " " .. url
+		elseif baidu == nil then
+			url = "--socks5 127.0.0.1:" .. socks_port .. " " .. url
 		end
 	end
 	local result = luci.sys.exec('curl --connect-timeout 3 -o /dev/null -I -sk -w "%{http_code}:%{time_appconnect}" ' .. url)


### PR DESCRIPTION
优化首页网站连接测试逻辑，更准确的判断“回国”、“全局”和其他代理出国模式。
1.当“回国”时，百度采用代理测试，其他网站采用直连测试。
2.当“全局”时，所有网站均采用代理测试。
3.以上1、2点都不匹配时则判定为出国模式，百度采用直连测试，其他网站采用代理测试。