### PR TITLE
luci: optimize smartdns config

### DIFF
--- a/luci-app-passwall/root/usr/share/passwall/helper_smartdns_add.lua
+++ b/luci-app-passwall/root/usr/share/passwall/helper_smartdns_add.lua
@@ -423,5 +423,5 @@ if not fs.access(CACHE_DNS_FILE) then
 	f_out:close()
 end
 fs.symlink(CACHE_DNS_FILE, SMARTDNS_CONF)
-sys.call(string.format('echo "conf-file %s" >> /etc/smartdns/custom.conf', SMARTDNS_CONF))
+sys.call(string.format('echo "conf-file %s" >> /etc/smartdns/custom.conf', string.gsub(SMARTDNS_CONF, appname, appname .. "*")))
 log("  - 请让SmartDNS作为Dnsmasq的上游或重定向！")


### PR DESCRIPTION
### 此PR仅作为讨论和参考。

将passwall的smartdns配置文件修改为带通配符的形式，避免在系统启动时smartdns在绝对路径下找不到配置文件而无法运行，导致客户端无法解析dns。

@nftbty 
我在路由上测试通过，觉得这样处理起来比较优雅，提交个PR求指教。