### PR TITLE
Optimize ChinaDNS-NG logic

### DIFF
--- a/luci-app-passwall/root/usr/share/passwall/app.sh
+++ b/luci-app-passwall/root/usr/share/passwall/app.sh
@@ -499,6 +499,12 @@ run_chinadns_ng() {
 		filter-qtype 65
 	EOF
 
+	dnsmasq_filter_aaaa=$(uci get dhcp.@dnsmasq[0].filter_aaaa)
+	[ "${dnsmasq_filter_aaaa}" = "1" ] && {
+		echo "no-ipv6" >> ${_CONF_FILE}
+		echolog "  - 已在 DHCP 服务中启用 IPv6 过滤，ChinaDNS-NG 将不再处理 IPv6 请求"
+	}
+
 	[ "${_use_direct_list}" = "1" ] && [ -s "${RULES_PATH}/direct_host" ] && {
 		local whitelist4_set="passwall_whitelist"
 		local whitelist6_set="passwall_whitelist6"
@@ -527,7 +533,7 @@ run_chinadns_ng() {
 			group-upstream ${_dns_trust}
 			group-ipset ${blacklist4_set},${blacklist6_set}
 		EOF
-		[ "${_no_ipv6_trust}" = "1" ] && echo "no-ipv6 tag:proxylist" >> ${_CONF_FILE}
+		[ "${dnsmasq_filter_aaaa}" != "1" ] && [ "${_no_ipv6_trust}" = "1" ] && echo "no-ipv6 tag:proxylist" >> ${_CONF_FILE}
 	}
 
 	[ "${_gfwlist}" = "1" ] && [ -s "${RULES_PATH}/gfwlist" ] && {
@@ -541,7 +547,7 @@ run_chinadns_ng() {
 			gfwlist-file ${RULES_PATH}/gfwlist
 			add-taggfw-ip ${gfwlist4_set},${gfwlist6_set}
 		EOF
-		[ "${_no_ipv6_trust}" = "1" ] && echo "no-ipv6 tag:gfw" >> ${_CONF_FILE}
+		[ "${dnsmasq_filter_aaaa}" != "1" ] && [ "${_no_ipv6_trust}" = "1" ] && echo "no-ipv6 tag:gfw" >> ${_CONF_FILE}
 	}
 
 	[ "${_chnlist}" != "0" ] && [ -s "${RULES_PATH}/chnlist" ] && {
@@ -570,7 +576,7 @@ run_chinadns_ng() {
 				group-upstream ${_dns_trust}
 				group-ipset ${chnroute4_set},${chnroute6_set}
 			EOF
-			[ "${_no_ipv6_trust}" = "1" ] && echo "no-ipv6 tag:chn_proxy" >> ${_CONF_FILE}
+			[ "${dnsmasq_filter_aaaa}" != "1" ] && [ "${_no_ipv6_trust}" = "1" ] && echo "no-ipv6 tag:chn_proxy" >> ${_CONF_FILE}
 		}
 	}
 
@@ -581,7 +587,7 @@ run_chinadns_ng() {
 	#全局模式，默认使用远程DNS
 	[ "${_default_mode}" = "proxy" ] && [ "${_chnlist}" = "0" ] && [ "${_gfwlist}" = "0" ] && {
 		_default_tag="gfw"
-		[ "${_no_ipv6_trust}" = "1" ] && echo "no-ipv6" >> ${_CONF_FILE}
+		[ "${dnsmasq_filter_aaaa}" != "1" ] && [ "${_no_ipv6_trust}" = "1" ] && echo "no-ipv6" >> ${_CONF_FILE}
 	}
 
 	([ -z "${_default_tag}" ] || [ "${_default_tag}" = "smart" ]) && _default_tag="none"


### PR DESCRIPTION
根据 Issues #3242 做了一些修改，之前有遇到过类似的问题，但没有具体分析，今天才发现是和 ChinaDNS-NG 有关。
该用户提出的增加 ```noip-as-chnip``` 参数，由于我目前对 lua 不太了解，所以暂时不弄了，替代方案思考了一下可以实现，修改后的逻辑是这样的：
在 openwrt dhcp/dns 高级设置中，有一个“禁止解析 IPv6 DNS 记录”的选项，开启后所有 AAAA 记录都会被过滤，既然用户选择启用该选项，即证明用户不希望使用 IPv6，我们可以直接在 ChinaDNS-NG 中过滤掉所有 AAAA 记录，即使远程 DNS 出现问题也不影响国内网站访问（即该用户描述的 tag:none 域名，但服务器 IP 是国内），这样也算是解决了 #3242 中提到的问题。