### PR TITLE
luci: add dns redirection and optimization

### DIFF
--- a/luci-app-passwall/luasrc/model/cbi/passwall/client/global.lua
+++ b/luci-app-passwall/luasrc/model/cbi/passwall/client/global.lua
@@ -402,7 +402,14 @@ o.description = "<ul>"
 		.. "</ul>"
 o:depends({dns_shunt = "dnsmasq", tcp_proxy_mode = "proxy", chn_list = "direct"})
 
-o = s:taboption("DNS", Button, "clear_ipset", translate("Clear IPSET"), translate("Try this feature if the rule modification does not take effect."))
+o = s:taboption("DNS", Flag, "dns_redirect", "DNS " .. translate("Redirect"), translate("Force Router DNS server to all local devices."))
+o.default = "0"
+
+if (uci:get(appname, "@global_forwarding[0]", "use_nft") or "0") == "1" then
+	o = s:taboption("DNS", Button, "clear_ipset", translate("Clear NFTSET"), translate("Try this feature if the rule modification does not take effect."))
+else
+	o = s:taboption("DNS", Button, "clear_ipset", translate("Clear IPSET"), translate("Try this feature if the rule modification does not take effect."))
+end
 o.inputstyle = "remove"
 function o.write(e, e)
 	luci.sys.call('[ -n "$(nft list sets 2>/dev/null | grep \"passwall_\")" ] && sh /usr/share/passwall/nftables.sh flush_nftset_reload || sh /usr/share/passwall/iptables.sh flush_ipset_reload > /dev/null 2>&1 &')

--- a/luci-app-passwall/po/zh-cn/passwall.po
+++ b/luci-app-passwall/po/zh-cn/passwall.po
@@ -187,8 +187,17 @@ msgstr "实验性功能。"
 msgid "Use FakeDNS work in the shunt domain that proxy."
 msgstr "需要代理的分流规则域名使用 FakeDNS。"
 
+msgid "Redirect"
+msgstr "重定向
+
+msgid "Force Router DNS server to all local devices."
+msgstr "强制所有本地设备使用路由器 DNS。"
+
 msgid "Clear IPSET"
 msgstr "清空 IPSET"
+
+msgid "Clear NFTSET"
+msgstr "清空 NFTSET"
 
 msgid "Try this feature if the rule modification does not take effect."
 msgstr "如果修改规则后没有生效，请尝试此功能。"

--- a/luci-app-passwall/po/zh-cn/passwall.po
+++ b/luci-app-passwall/po/zh-cn/passwall.po
@@ -188,7 +188,7 @@ msgid "Use FakeDNS work in the shunt domain that proxy."
 msgstr "需要代理的分流规则域名使用 FakeDNS。"
 
 msgid "Redirect"
-msgstr "重定向
+msgstr "重定向"
 
 msgid "Force Router DNS server to all local devices."
 msgstr "强制所有本地设备使用路由器 DNS。"

--- a/luci-app-passwall/root/usr/share/passwall/iptables.sh
+++ b/luci-app-passwall/root/usr/share/passwall/iptables.sh
@@ -1108,6 +1108,16 @@ add_firewall_rule() {
 		
 		$ip6t_m -I OUTPUT $(comment "mangle-OUTPUT-PSW") -o lo -j RETURN
 		insert_rule_before "$ip6t_m" "OUTPUT" "mwan3" "$(comment mangle-OUTPUT-PSW) -m mark --mark 1 -j RETURN"
+
+		[ $(config_t_get global dns_redirect) == "1" ] && {
+			$ipt_m -A PSW -p udp --dport 53 -j RETURN	
+			$ip6t_m -A PSW -p udp --dport 53 -j RETURN
+			$ipt_n -I PREROUTING -p udp --dport 53 -j REDIRECT --to-ports 53 -m comment --comment "PSW_DNS_Hijack" 2>/dev/null
+			$ipt_n -I PREROUTING -p tcp --dport 53 -j REDIRECT --to-ports 53 -m comment --comment "PSW_DNS_Hijack" 2>/dev/null
+			$ip6t_n -I PREROUTING -p udp --dport 53 -j REDIRECT --to-ports 53 -m comment --comment "PSW_DNS_Hijack" 2>/dev/null
+			$ip6t_n -I PREROUTING -p tcp --dport 53 -j REDIRECT --to-ports 53 -m comment --comment "PSW_DNS_Hijack" 2>/dev/null
+		}
+
 	}
 
 	#  加载ACLS

--- a/luci-app-passwall/root/usr/share/passwall/nftables.sh
+++ b/luci-app-passwall/root/usr/share/passwall/nftables.sh
@@ -1149,6 +1149,17 @@ add_firewall_rule() {
 
 		nft "add rule inet fw4 mangle_output oif lo counter return comment \"PSW_OUTPUT_MANGLE\""
 		nft "add rule inet fw4 mangle_output meta mark 1 counter return comment \"PSW_OUTPUT_MANGLE\""
+
+		[ $(config_t_get global dns_redirect) == "1" ] && {
+			nft "add rule inet fw4 PSW_MANGLE ip protocol udp udp dport 53 counter return"	
+			nft "add rule inet fw4 PSW_MANGLE_V6 meta l4proto udp udp dport 53 counter return"
+			nft insert rule inet fw4 dstnat position 0 tcp dport 53 counter redirect to :53 comment \"PSW_DNS_Hijack\" 2>/dev/null
+			nft insert rule inet fw4 dstnat position 0 udp dport 53 counter redirect to :53 comment \"PSW_DNS_Hijack\" 2>/dev/null
+			nft insert rule inet fw4 dstnat position 0 meta nfproto {ipv6} tcp dport 53 counter redirect to :53 comment \"PSW_DNS_Hijack\" 2>/dev/null
+			nft insert rule inet fw4 dstnat position 0 meta nfproto {ipv6} udp dport 53 counter redirect to :53 comment \"PSW_DNS_Hijack\" 2>/dev/null
+			uci -q set dhcp.@dnsmasq[0].dns_redirect='0' 2>/dev/null
+			uci commit dhcp 2>/dev/null
+		}
 	}
 
 	#  加载ACLS


### PR DESCRIPTION
1.添加DNS重定向设置（dns劫持）；
2.顺手优化了“清空 ipset”按钮显示，根据所使用的防火墙工具，该按钮显示为：“清空 NFTSET” 或者 “清空 IPSET” 。

![1](https://github.com/xiaorouji/openwrt-passwall/assets/86697442/d398e33e-ee10-408a-90ea-24f9e8ab4d73)
