### PR TITLE
luci: user-agent optimization

### DIFF
--- a/luci-app-passwall/luasrc/model/cbi/passwall/client/node_subscribe_config.lua
+++ b/luci-app-passwall/luasrc/model/cbi/passwall/client/node_subscribe_config.lua
@@ -167,10 +167,11 @@ o:depends("week_update", "8")
 o.rmempty = true
 
 o = s:option(Value, "user_agent", translate("User-Agent"))
-o.default = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36 Edg/122.0.0.0"
-o:value("curl")
-o:value("Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36 Edg/122.0.0.0")
-o:value("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36 Edg/122.0.0.0")
-o:value("Passwall/OpenWrt")
+o.default = "sing-box/9.9.9"
+o:value("curl", "Curl Default")
+o:value("Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36 Edg/122.0.0.0", "Edge for Linux")
+o:value("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36 Edg/122.0.0.0", "Edge for Windows")
+o:value("Passwall/OpenWrt", "PassWall")
+o:value("sing-box/9.9.9", "Xboard(V2board)")
 
 return m


### PR DESCRIPTION
目前大部分机场都是采用Xboard(V2board)面板，用户在订阅时Xboard面板会通过ua获取客户端类型和版本，从而判断该客户端是否支持某些协议，如果客户端不复合要求则不推送相关协议的节点链接。目前包括passwall在内的所有路由上的代理插件都不在Xboard的列表中，这样就导致了一些pw用户在订阅时没有获取到节点信息。针对这个情况修改和优化了一下pw的ua设置，可发送sing-box的信息，让Xboard推送所有协议节点链接。