### PR TITLE
luci: modify user-agent string

### DIFF
--- a/luci-app-passwall/luasrc/model/cbi/passwall/client/node_subscribe_config.lua
+++ b/luci-app-passwall/luasrc/model/cbi/passwall/client/node_subscribe_config.lua
@@ -176,11 +176,11 @@ o:depends("week_update", "8")
 o.rmempty = true
 
 o = s:option(Value, "user_agent", translate("User-Agent"))
-o.default = "sing-box/9.9.9"
+o.default = "v2rayN/9.99"
 o:value("curl", "Curl Default")
 o:value("Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36 Edg/122.0.0.0", "Edge for Linux")
 o:value("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36 Edg/122.0.0.0", "Edge for Windows")
 o:value("Passwall/OpenWrt", "PassWall")
-o:value("sing-box/9.9.9", "Xboard(V2board)")
+o:value("v2rayN/9.99", "Xboard(V2board)")
 
 return m

--- a/luci-app-passwall/luasrc/model/cbi/passwall/client/node_subscribe_config.lua
+++ b/luci-app-passwall/luasrc/model/cbi/passwall/client/node_subscribe_config.lua
@@ -181,6 +181,6 @@ o:value("curl", "Curl Default")
 o:value("Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36 Edg/122.0.0.0", "Edge for Linux")
 o:value("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36 Edg/122.0.0.0", "Edge for Windows")
 o:value("Passwall/OpenWrt", "PassWall")
-o:value("v2rayN/9.99", "Xboard(V2board)")
+o:value("v2rayN/9.99", "V2rayN")
 
 return m

--- a/luci-app-passwall/luasrc/model/cbi/passwall/client/node_subscribe_config.lua
+++ b/luci-app-passwall/luasrc/model/cbi/passwall/client/node_subscribe_config.lua
@@ -177,7 +177,7 @@ o.rmempty = true
 
 o = s:option(Value, "user_agent", translate("User-Agent"))
 o.default = "v2rayN/9.99"
-o:value("curl", "Curl Default")
+o:value("curl", "Curl")
 o:value("Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36 Edg/122.0.0.0", "Edge for Linux")
 o:value("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36 Edg/122.0.0.0", "Edge for Windows")
 o:value("Passwall/OpenWrt", "PassWall")


### PR DESCRIPTION
了解到有机场会根据ua给sing-box客户端发送专用配置，所以将user-agent设置中Xboard(V2board)的ua字符串改成通用客户端v2rayN，以防万一。