### PR TITLE
nftables: fix high CPU usage in specific situations

### DIFF
--- a/luci-app-passwall/root/usr/share/passwall/nftables.sh
+++ b/luci-app-passwall/root/usr/share/passwall/nftables.sh
@@ -916,7 +916,8 @@ add_firewall_rule() {
 
 	WAN_IP=$(get_wan_ip)
 	if [ -n "${WAN_IP}" ]; then
-		[ -n "${is_tproxy}" ] && nft "add rule inet fw4 PSW_MANGLE ip daddr ${WAN_IP} counter return comment \"WAN_IP_RETURN\"" || nft "add rule inet fw4 PSW_NAT ip daddr ${WAN_IP} counter return comment \"WAN_IP_RETURN\""
+		nft "add rule inet fw4 PSW_MANGLE ip daddr ${WAN_IP} counter return comment \"WAN_IP_RETURN\""
+		[ -z "${is_tproxy}" ] && nft "add rule inet fw4 PSW_NAT ip daddr ${WAN_IP} counter return comment \"WAN_IP_RETURN\""
 	fi
 	unset WAN_IP
 


### PR DESCRIPTION
原始问题来自PW2的讨论：https://github.com/xiaorouji/openwrt-passwall2/issues/613

根据查看nftables的代码，tproxy负责udp代理，不受tcp代理方式的影响，所以原代码在tcp代理方式采用REDIRECT时，没有将wan ip加入到PSW_MANGLE中进行return操作，这样就有可能会在某种情况下产生上面PW2那个讨论帖子中的问题。