### PR TITLE
luci: app_update adapt chinadns-ng wolfssl version

### DIFF
--- a/luci-app-passwall/luasrc/passwall/api.lua
+++ b/luci-app-passwall/luasrc/passwall/api.lua
@@ -14,6 +14,7 @@ curl_args = { "-skfL", "--connect-timeout 3", "--retry 3" }
 command_timeout = 300
 OPENWRT_ARCH = nil
 DISTRIB_ARCH = nil
+OPENWRT_BOARD = nil
 
 LOG_FILE = "/tmp/log/" .. appname .. ".log"
 CACHE_PATH = "/tmp/etc/" .. appname .. "_tmp"
@@ -620,7 +621,9 @@ local function auto_get_arch()
 	local arch = nixio.uname().machine or ""
 	if not OPENWRT_ARCH and fs.access("/usr/lib/os-release") then
 		OPENWRT_ARCH = sys.exec("echo -n $(grep 'OPENWRT_ARCH' /usr/lib/os-release | awk -F '[\\042\\047]' '{print $2}')")
+		OPENWRT_BOARD = sys.exec("echo -n $(grep 'OPENWRT_BOARD' /usr/lib/os-release | awk -F '[\\042\\047]' '{print $2}')")
 		if OPENWRT_ARCH == "" then OPENWRT_ARCH = nil end
+		if OPENWRT_BOARD == "" then OPENWRT_BOARD = nil end
 	end
 	if not DISTRIB_ARCH and fs.access("/etc/openwrt_release") then
 		DISTRIB_ARCH = sys.exec("echo -n $(grep 'DISTRIB_ARCH' /etc/openwrt_release | awk -F '[\\042\\047]' '{print $2}')")
@@ -649,6 +652,10 @@ local function auto_get_arch()
 				arch = "armv5"
 			end
 		end
+	end
+
+	if arch == "aarch64" and OPENWRT_BOARD and OPENWRT_BOARD:match("rockchip") ~= nil then
+		arch = "rockchip"
 	end
 
 	return util.trim(arch)
@@ -696,8 +703,9 @@ local default_file_tree = {
 	x86_64  = "amd64",
 	x86     = "386",
 	aarch64 = "arm64",
+	rockchip = "arm64",
 	mips    = "mips",
-	mipsel  = "mipsle",
+	mipsel  = "mipsel",
 	armv5   = "arm.*5",
 	armv6   = "arm.*6[^4]*",
 	armv7   = "arm.*7",

--- a/luci-app-passwall/luasrc/passwall/com.lua
+++ b/luci-app-passwall/luasrc/passwall/com.lua
@@ -62,15 +62,16 @@ _M["chinadns-ng"] = {
 	default_path = "/usr/bin/chinadns-ng",
 	match_fmt_str = "%s",
 	file_tree = {
-		x86_64  = "x86_64@",
-		x86     = "i686",
-		mips    = "mips%-.*mips32%+soft_float@",
-		mipsel  = "mipsel.*mips32%+soft_float@",
-		aarch64 = "aarch64.*v8a",
-		armv5   = "arm.*v5te",
-		armv6   = "arm.*v6t2",
-		armv7   = "eabihf.*v7a",
-		armv8   = "aarch64.*v8a"
+		x86_64  = "wolfssl@x86_64.*x86_64@",
+		x86     = "wolfssl@i386.*i686",
+		mips    = "wolfssl@mips%-.*mips32%+soft_float@",
+		mipsel  = "wolfssl@mipsel.*mips32%+soft_float@",
+		aarch64 = "wolfssl_noasm@aarch64.*v8a",
+		rockchip = "wolfssl@aarch64.*v8a",
+		armv5   = "wolfssl@arm.*v5te",
+		armv6   = "wolfssl@arm.*v6t2",
+		armv7   = "wolfssl@arm.*eabihf.*v7a",
+		armv8   = "wolfssl_noasm@aarch64.*v8a"
 	}
 }
 


### PR DESCRIPTION
修改chinadns-ng的程序更新为wolfssl版本（rockchip为支持aes硬件加速的版本），支持DoT上游，为今后PW的chinadns-ng可能适配DoT查询先打好基础。