### PR TITLE
luci: node_list _now_use dark background

### DIFF
--- a/luci-app-passwall/luasrc/view/passwall/node_list/node_list.htm
+++ b/luci-app-passwall/luasrc/view/passwall/node_list/node_list.htm
@@ -32,6 +32,12 @@ table td, .table .td {
 .ping a:hover{
 	text-decoration : underline;
 }
+
+@media (prefers-color-scheme: dark) {
+    ._now_use {
+        background: #4a90e2 !important;
+    }
+}
 </style>
 
 <script type="text/javascript">


### PR DESCRIPTION
如果非 dark 模式下使用的是 #94e1ff 这种较为明亮的淡蓝色，在 dark 模式下，通常需要选择一个稍暗的配色，以避免过于刺眼，同时保持视觉的和谐。

匹配 #94e1ff 的深色模式背景色，建议使用以下颜色之一：

 - #4a90e2 — 更深的蓝色调，适合深色背景，视觉上不刺眼。
 - #357abd — 稍微暗一些的蓝色，和 #94e1ff 在色调上接近，但更适合暗背景。
 - #3b6bb2 — 适中的深蓝色，保持了冷静的感觉，也能很好地融入暗色模式。
 - #2b5c97 — 稍深的蓝色，和明亮的 #94e1ff 有良好对比。
 - #5a9bd3 — 带有一点柔和的蓝色，不会显得过于暗沉，保持了活力感。

综合推荐使用 #4a90e2，因为它与 #94e1ff 的亮度和色调最接近，但在深色背景下依然保持足够的对比度和舒适性。