### PR TITLE
luci: add apple intelligence rule

### DIFF
--- a/luci-app-passwall/root/usr/share/passwall/0_default_config
+++ b/luci-app-passwall/root/usr/share/passwall/0_default_config
@@ -163,7 +163,8 @@ domain:store.steampowered.com'
 
 config shunt_rules 'AIGC'
 	option remarks 'AIGC'
-	option domain_list 'geosite:category-ai-chat-!cn'
+	option domain_list 'geosite:category-ai-chat-!cn
+domain:apple-relay.apple.com'
 
 config shunt_rules 'Streaming'
 	option remarks 'Streaming'

--- a/luci-app-passwall/root/usr/share/passwall/rules/proxy_host
+++ b/luci-app-passwall/root/usr/share/passwall/rules/proxy_host
@@ -2,6 +2,7 @@ engage.cloudflareclient.com
 github.com
 bing.com
 c.mi.com
+apple-relay.apple.com
 
 #google
 googleapis.cn


### PR DESCRIPTION
域名来自：https://support.apple.com/zh-hk/101555
如果不正确分流此域名，将导致无法正常使用 ChatGPT 相关功能。