### PR TITLE
luci: cleaned up redundant classes in FAQ page elements

### DIFF
--- a/luci-app-passwall/luasrc/view/passwall/global/faq.htm
+++ b/luci-app-passwall/luasrc/view/passwall/global/faq.htm
@@ -28,7 +28,7 @@ local api = require "luci.passwall.api"
 		line-height: 1.2rem;
 }
 </style>
-<div class="cbi-section cbi-tblsection dns-con">
+<div class="dns-con">
 	<div id="faq_dns">
 		<ul>
             <b class="faq-title"><%:DNS related issues:%></b>


### PR DESCRIPTION
在不同主题下可能会对这些多余的样式类复写，导致意料之外的情况