### PR TITLE
Support custom chinadns config

### DIFF
--- a/luci-app-passwall/root/usr/share/passwall/helper_chinadns_add.lua
+++ b/luci-app-passwall/root/usr/share/passwall/helper_chinadns_add.lua
@@ -517,6 +517,14 @@ else
 	log(string.format("  - 默认 DNS ：%s", "智能匹配"))
 end
 
+--追加自定义配置
+local file_custom_config = RULES_PATH .. "/chinadns_custom_config"
+if fs.access(file_custom_config) then
+	for line in io.lines(file_custom_config) do
+		table.insert(config_lines, line)
+	end
+end
+
 --输出配置文件
 if #config_lines > 0 then
 	for i = 1, #config_lines do


### PR DESCRIPTION
Partially fix #4021

No GUI support now.

By this, I can create a file `/usr/share/passwall/rules/chinadns_custom_config` with content:
```
group company
group-dnl /usr/share/passwall/rules/company
group-upstream 10.0.0.1
```

and use `10.0.0.1` to resolve domains in `/usr/share/passwall/rules/company`