### PR TITLE
feat: Remove tcpNoDelay option from Xray client configuration

### DIFF
--- a/luci-app-passwall/luasrc/model/cbi/passwall/client/type/ray.lua
+++ b/luci-app-passwall/luasrc/model/cbi/passwall/client/type/ray.lua
@@ -677,9 +677,6 @@ o:depends({ [_n("xmux")] = true })
 o = s:option(Flag, _n("tcpMptcp"), "tcpMptcp", translate("Enable Multipath TCP, need to be enabled in both server and client configuration."))
 o.default = 0
 
-o = s:option(Flag, _n("tcpNoDelay"), "tcpNoDelay")
-o.default = 0
-
 o = s:option(ListValue, _n("chain_proxy"), translate("Chain Proxy"))
 o:value("", translate("Close(Not use)"))
 o:value("1", translate("Preproxy Node"))
@@ -706,7 +703,6 @@ end
 for i, v in ipairs(s.fields[_n("protocol")].keylist) do
 	if not v:find("_") then
 		s.fields[_n("tcpMptcp")]:depends({ [_n("protocol")] = v })
-		s.fields[_n("tcpNoDelay")]:depends({ [_n("protocol")] = v })
 		s.fields[_n("chain_proxy")]:depends({ [_n("protocol")] = v })
 	end
 end

--- a/luci-app-passwall/luasrc/passwall/util_xray.lua
+++ b/luci-app-passwall/luasrc/passwall/util_xray.lua
@@ -147,7 +147,6 @@ function gen_outbound(flag, node, tag, proxy_table)
 				sockopt = {
 					mark = 255,
 					tcpMptcp = (node.tcpMptcp == "1") and true or nil,
-					tcpNoDelay = (node.tcpNoDelay == "1") and true or nil,
 					dialerProxy = (fragment or noise) and "dialerproxy" or nil
 				},
 				network = node.transport,
@@ -1477,8 +1476,7 @@ function gen_config(var)
 				},
 				streamSettings = {
 					sockopt = {
-						mark = 255,
-						tcpNoDelay = true
+						mark = 255
 					}
 				}
 			})


### PR DESCRIPTION
Xray核心中已经移除tcpNoDelay配置项。
[https://xtls.github.io/config/transport.html#sockoptobject](https://xtls.github.io/config/transport.html#sockoptobject)