### PR TITLE
XHTTP 不应使用 mux.cool 模块，其通过 xhttpSettings.extra 独立配置 xmux 信息

### DIFF
--- a/luci-app-passwall/luasrc/model/cbi/passwall/client/type/ray.lua
+++ b/luci-app-passwall/luasrc/model/cbi/passwall/client/type/ray.lua
@@ -658,7 +658,6 @@ o:depends({ [_n("mux")] = true })
 o = s:option(Flag, _n("xmux"), "XUDP Mux")
 o.default = 1
 o:depends({ [_n("protocol")] = "vless", [_n("flow")] = "xtls-rprx-vision" })
-o:depends({ [_n("protocol")] = "vless", [_n("transport")] = "xhttp" })
 
 o = s:option(Value, _n("xudp_concurrency"), translate("XUDP Mux concurrency"))
 o.default = 8


### PR DESCRIPTION
XHTTP 不应使用 mux.cool 模块，其通过 xhttpSettings.extra 独立配置 xmux 信息
Fix #4060